### PR TITLE
[Feat/32] 나의 업무 UI 구현

### DIFF
--- a/src/app/(main)/home/tasks/page.tsx
+++ b/src/app/(main)/home/tasks/page.tsx
@@ -1,8 +1,17 @@
+'use client';
+
+import MyTaskBoard from '@/features/boards/MyTaskBoard';
+
 export default function TaskPage() {
   return (
-    <div className="flex flex-col items-center h-screen py-20">
-      <h1 className="text-2xl font-bold mb-4">나의 업무</h1>
-      <p className="text-gray-600">이런 식으로 페이지를 작성하시면 됩니다!</p>
+    <div className="min-h-screen w-full bg-white flex flex-col">
+      <header className="flex items-center justify-between pb-[16px] px-[8px] border-b-[2px] border-[#E7E7E7]">
+        <h1 className="text-[24px] font-bold">나의 업무</h1>
+      </header>
+
+      <main className="flex-1 overflow-x-auto">
+        <MyTaskBoard />
+      </main>
     </div>
   );
 }

--- a/src/features/boards/MyTaskBoard.tsx
+++ b/src/features/boards/MyTaskBoard.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import TaskItem from '@/components/TaskItem';
+import { mockProjects } from '@/constants/mockData';
+import ProjectHeader from './components/ProjectHeader';
+
+// 임시 로그인 사용자
+const currentUser = '홍길동';
+
+export default function MyTaskBoard() {
+  // 프로젝트별로, 모든 step의 items 중 담당자가 currentUser인 태스크만 한 배열로 합침
+  const filteredProjects = mockProjects.map((project) => ({
+    ...project,
+    myTasks: project.steps
+      .flatMap((step) => step.items)
+      .filter((task) => task.assignee && task.assignee.includes(currentUser)),
+  }));
+
+  // 아코디언 상태 관리 (기본: 모두 펼침)
+  const [openProjectIds, setOpenProjectIds] = useState<string[]>(filteredProjects.map((p) => p.id));
+
+  const handleToggle = (projectId: string) => {
+    setOpenProjectIds((prev) =>
+      prev.includes(projectId) ? prev.filter((id) => id !== projectId) : [...prev, projectId]
+    );
+  };
+
+  return (
+    <div className="grid grid-cols-4 gap-x-[36px] gap-y-[60px] mt-[60px] px-[35px]">
+      {filteredProjects.map((project) => (
+        <div key={project.id} className="flex flex-col">
+          <ProjectHeader
+            projectName={project.name}
+            isOpen={openProjectIds.includes(project.id)}
+            onToggle={() => handleToggle(project.id)}
+          />
+          {openProjectIds.includes(project.id) && (
+            <div className="flex flex-col gap-3 mt-6">
+              {project.myTasks.map((task) => (
+                <TaskItem
+                  key={task.id}
+                  projectId={project.id}
+                  id={task.id}
+                  title={task.title}
+                  status={task.status}
+                  deadline={task.deadline}
+                  assignee={task.assignee}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/boards/components/ProjectHeader.tsx
+++ b/src/features/boards/components/ProjectHeader.tsx
@@ -1,0 +1,19 @@
+interface ProjectHeaderProps {
+  projectName: string;
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+export default function ProjectHeader({ projectName, isOpen, onToggle }: ProjectHeaderProps) {
+  return (
+    <button onClick={onToggle} className="cursor-pointer">
+      <div className="flex bg-[#DAF3F3] w-[325px] h-[68px] items-center justify-between rounded-[8px]">
+        <span className="font-medium text-[18px] mx-auto">{projectName}</span>
+        <img
+          src="/icons/arrow-down.svg"
+          className={`w-[32px] h-[32px] mr-[4px] ${isOpen ? 'rotate-180' : ''}`}
+        />
+      </div>
+    </button>
+  );
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #32 

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
<img width="2234" height="1037" alt="image" src="https://github.com/user-attachments/assets/11a75d71-19fc-4362-a2de-97b8de1188e8" />

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 지금은 Navbar나 나의 업무 페이지 ProjectHeader 컴포넌트에서 mockData 안의 프로젝트를 전부 map으로 돌리고 있습니다. API 연결 시에 해당 파트 전부 API response를 출력하는 걸로 변경할 예정입니다.
- 아코디언 부분이 UseSteps에서 쓰는 코드랑 중복일 듯 하여 차후에 훅을 개별적으로 분리할까 고민 중입니다.

## 첨부 자료
-
