### PR TITLE
[Feat/44] 나의 업무 페이지 반응형 UI 구현

### DIFF
--- a/src/app/(main)/home/tasks/page.tsx
+++ b/src/app/(main)/home/tasks/page.tsx
@@ -4,12 +4,12 @@ import MyTaskBoard from '@/features/boards/MyTaskBoard';
 
 export default function TaskPage() {
   return (
-    <div className="min-h-screen w-full bg-white flex flex-col">
+    <div className="min-h-screen w-full bg-white">
       <header className="flex items-center justify-between pb-[16px] px-[8px] border-b-[2px] border-[#E7E7E7]">
         <h1 className="text-[24px] font-bold">나의 업무</h1>
       </header>
 
-      <main className="flex-1 overflow-x-auto">
+      <main>
         <MyTaskBoard />
       </main>
     </div>

--- a/src/app/(main)/home/tasks/page.tsx
+++ b/src/app/(main)/home/tasks/page.tsx
@@ -5,8 +5,8 @@ import MyTaskBoard from '@/features/boards/MyTaskBoard';
 export default function TaskPage() {
   return (
     <div className="min-h-screen w-full bg-white">
-      <header className="flex items-center justify-between pb-[16px] px-[8px] border-b-[2px] border-[#E7E7E7]">
-        <h1 className="text-[24px] font-bold">나의 업무</h1>
+      <header className="flex items-center justify-between pb-[1rem] px-[0.5rem] border-b-[0.125rem] border-[#E7E7E7]">
+        <h1 className="text-[1.375rem] lg:text-[1.5rem] font-semibold lg:font-bold">나의 업무</h1>
       </header>
 
       <main>

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -17,11 +17,20 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="ko" className={pretendard.className}>
       <body className="bg-white">
         <Navbar />
-        <div className="flex min-h-screen">
+        <div className="flex min-h-screen overflow-x-auto">
           <div className="w-[185px] min-h-screen flex-none">
             <Sidebar />
           </div>
-          <main className="flex-1 px-[120px] py-[60px]">{children}</main>
+          <main
+            className="flex-1 min-w-[1024px] py-[3.75rem]"
+            style={{
+              /* 패딩 - 1920px 기준 160px, 1024px 기준 24px */
+              paddingLeft: 'clamp(1.5rem, calc(15.179vw - 8.214rem), 10rem)',
+              paddingRight: 'clamp(1.5rem, calc(15.179vw - 8.214rem), 10rem)',
+            }}
+          >
+            {children}
+          </main>
         </div>
       </body>
     </html>

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="bg-white">
         <Navbar />
         <div className="flex min-h-screen overflow-x-auto">
-          <div className="w-[185px] min-h-screen flex-none">
+          <div className="min-h-screen flex-none">
             <Sidebar />
           </div>
           <main

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -24,9 +24,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <main
             className="flex-1 min-w-[1024px] py-[3.75rem]"
             style={{
-              /* 패딩 - 1920px 기준 160px, 1024px 기준 24px */
-              paddingLeft: 'clamp(1.5rem, calc(15.179vw - 8.214rem), 10rem)',
-              paddingRight: 'clamp(1.5rem, calc(15.179vw - 8.214rem), 10rem)',
+              /* 패딩 - 1920px 기준 120px, 1024px 기준 24px */
+              paddingLeft: 'clamp(1.5rem, calc(15.179vw - 8.214rem), 7.5rem)',
+              paddingRight: 'clamp(1.5rem, calc(15.179vw - 8.214rem), 7.5rem)',
             }}
           >
             {children}

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -15,9 +15,9 @@ const pretendard = localFont({
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko" className={pretendard.className}>
-      <body className="bg-white">
+      <body className="bg-white overflow-x-hidden">
         <Navbar />
-        <div className="flex min-h-screen overflow-x-auto">
+        <div className="flex min-h-screen">
           <div className="min-h-screen flex-none">
             <Sidebar />
           </div>

--- a/src/app/(main)/new/create/page.tsx
+++ b/src/app/(main)/new/create/page.tsx
@@ -1,8 +1,0 @@
-export default function CreatePage() {
-  return (
-    <div className="flex flex-col items-center h-screen py-20">
-      <h1 className="text-2xl font-bold mb-4">프로젝트 생성</h1>
-      <p className="text-gray-600">이런 식으로 페이지를 작성하시면 됩니다!</p>
-    </div>
-  );
-}

--- a/src/app/(main)/new/join/page.tsx
+++ b/src/app/(main)/new/join/page.tsx
@@ -1,8 +1,0 @@
-export default function JoinPage() {
-  return (
-    <div className="flex flex-col items-center h-screen py-20">
-      <h1 className="text-2xl font-bold mb-4">프로젝트 참여</h1>
-      <p className="text-gray-600">이런 식으로 페이지를 작성하시면 됩니다!</p>
-    </div>
-  );
-}

--- a/src/app/(main)/new/page.tsx
+++ b/src/app/(main)/new/page.tsx
@@ -1,5 +1,8 @@
-import { redirect } from 'next/navigation';
-
 export default function New() {
-  redirect('/new/create');
+  return (
+    <div className="flex flex-col items-center h-screen py-20">
+      <h1 className="text-2xl font-bold mb-4">프로젝트 생성</h1>
+      <p className="text-gray-600">이런 식으로 페이지를 작성하시면 됩니다!</p>
+    </div>
+  );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -28,6 +28,10 @@ export default function Navbar() {
     { label: '나의 프로젝트', key: 'projects' },
   ];
 
+  const upgradeButtonClick = () => {
+    window.alert('업그레이드 버튼 클릭 ^____^');
+  };
+
   return (
     <nav className="w-full border-b-[0.125rem] border-[#E7E7E7] bg-white h-[3.625rem] z-10 relative">
       <div className="flex items-center h-full px-[1.313rem] min-w-[1024px]">
@@ -117,8 +121,11 @@ export default function Navbar() {
 
         {/* 오른쪽 고정 영역 */}
         <div className="flex items-center gap-[2.25rem] shrink-0 mr-[0.563rem]">
-          <button className="w-[8.938rem] h-[2rem] bg-[#81D7D4] text-white rounded-[0.25rem] text-sm font-bold text-[1rem]">
-            pro로 업그레이드
+          <button
+            className="w-[8.938rem] h-[2rem] bg-[#81D7D4] text-white rounded-[0.25rem] text-sm font-bold text-[1rem]"
+            onClick={upgradeButtonClick}
+          >
+            PRO로 업그레이드
           </button>
           <ProfileDropdown />
         </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -29,7 +29,7 @@ export default function Navbar() {
 
   return (
     <nav className="w-full border-b-[0.125rem] border-[#E7E7E7] bg-white h-[3.625rem] z-10 relative">
-      <div className="flex items-center h-full px-[1.313rem] min-w-tablet">
+      <div className="flex items-center h-full px-[1.313rem] min-w-[1024px]">
         {/* 로고 */}
         <img
           src="/logo.svg"

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -28,23 +28,29 @@ export default function Navbar() {
   ];
 
   return (
-    <nav className="w-full border-b-[2px] border-[#E7E7E7] bg-white h-[58px] z-10 relative">
-      <div className="max-w-[1920px] mx-auto flex items-center h-full">
-        <img src="/logo.svg" alt="Teamie 로고" className="h-[23px] mt-[1px] ml-[21px]" />
+    <nav className="w-full border-b-[0.125rem] border-[#E7E7E7] bg-white h-[3.625rem] z-10 relative">
+      <div className="flex items-center h-full px-[1.313rem] min-w-tablet">
+        {/* 로고 */}
+        <img
+          src="/logo.svg"
+          alt="Teamie 로고"
+          className="h-[1.438rem] mt-[0.063rem] mr-[3.75rem] shrink-0"
+        />
 
-        <div className="flex items-center ml-[61px] gap-[60px] relative">
+        {/* 왼쪽 고정 영역 */}
+        <div className="flex items-center gap-[3.75rem] shrink-0">
           {menuConfigs.map(({ label, key, urlFn }) => (
             <div key={key} className="relative">
               <button
                 onClick={() => toggleMenu(key)}
-                className={`flex items-center cursor-pointer ${
+                className={`flex items-center cursor-pointer whitespace-nowrap ${
                   openMenu === key ? 'text-[#81D7D4]' : 'text-black'
                 }`}
               >
-                <span className="font-normal text-[18px]">{label}</span>
+                <span className="font-normal text-[1.125rem]">{label}</span>
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  className={`ml-[2px] w-[24px] h-[24px] ${openMenu === key ? 'rotate-180' : ''}`}
+                  className={`ml-[0.125rem] w-[1.5rem] h-[1.5rem] ${openMenu === key ? 'rotate-180' : ''}`}
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -58,18 +64,19 @@ export default function Navbar() {
                 </svg>
               </button>
 
+              {/* 드롭다운 */}
               {openMenu === key && (
-                <ul className="absolute mt-[12px] bg-white rounded-[8px] shadow-[0_0_15px_rgba(0,0,0,0.2)] z-20">
+                <ul className="absolute mt-[0.75rem] bg-white rounded-[0.5rem] shadow-[0_0_15px_rgba(0,0,0,0.2)] z-20">
                   {key === 'projects'
                     ? mockProjects.map((project) => (
                         <li
                           key={project.id}
-                          className="mx-[8px] border-b-[2px] border-[#BBBBBB] last:border-none"
+                          className="mx-[0.5rem] border-b-[0.125rem] border-[#BBBBBB] last:border-none"
                         >
                           <Link
                             href={`/projects/${project.id}`}
                             onClick={() => setOpenMenu(null)}
-                            className="block pl-[12px] pr-[150px] py-[12px] text-[#505050] text-[18px] whitespace-nowrap"
+                            className="block pl-[0.75rem] pr-[9.375rem] py-[0.75rem] text-[#505050] text-[1.125rem] whitespace-nowrap"
                           >
                             {project.name}
                           </Link>
@@ -78,12 +85,12 @@ export default function Navbar() {
                     : menus[key].map((item) => (
                         <li
                           key={item.path}
-                          className="mx-[8px] border-b-[2px] border-[#BBBBBB] last:border-none"
+                          className="mx-[0.5rem] border-b-[0.125rem] border-[#BBBBBB] last:border-none"
                         >
                           <Link
                             href={urlFn!(item.path)}
                             onClick={() => setOpenMenu(null)}
-                            className="block pl-[12px] pr-[150px] py-[12px] text-[#505050] text-[18px] whitespace-nowrap"
+                            className="block pl-[0.75rem] pr-[9.375rem] py-[0.75rem] text-[#505050] text-[1.125rem] whitespace-nowrap"
                           >
                             {item.name}
                           </Link>
@@ -95,12 +102,16 @@ export default function Navbar() {
           ))}
         </div>
 
-        <div className="flex items-center ml-auto">
-          <button className="w-[143px] h-[32px] bg-[#81D7D4] text-white rounded-[4px] text-sm font-bold text-[16px] mr-[36px]">
+        {/* 길이 조절되는 부분*/}
+        <div className="flex-1" />
+
+        {/* 오른쪽 고정 영역 */}
+        <div className="flex items-center gap-[2.25rem] shrink-0 mr-[0.563rem]">
+          <button className="w-[8.938rem] h-[2rem] bg-[#81D7D4] text-white rounded-[0.25rem] text-sm font-bold text-[1rem]">
             pro로 업그레이드
           </button>
+          <ProfileDropdown />
         </div>
-        <ProfileDropdown />
       </div>
     </nav>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useState } from 'react';
 import { menus } from '@/constants/menus';
-import { getHomeUrl, getNewUrl } from '@/utils/url';
+import { getHomeUrl } from '@/utils/url';
 import { mockProjects } from '@/constants/mockData';
 import { SidebarMenus } from '@/types/sidebar';
 import ProfileDropdown from './ProfileDropdown';
@@ -21,9 +21,10 @@ export default function Navbar() {
     label: string;
     key: MenuKey | 'projects';
     urlFn?: (path: string) => string;
+    isDirectLink?: boolean;
   }[] = [
     { label: '홈', key: 'home', urlFn: getHomeUrl },
-    { label: '프로젝트 추가', key: 'new', urlFn: getNewUrl },
+    { label: '프로젝트 생성', key: 'new', isDirectLink: true },
     { label: '나의 프로젝트', key: 'projects' },
   ];
 
@@ -39,33 +40,42 @@ export default function Navbar() {
 
         {/* 왼쪽 고정 영역 */}
         <div className="flex items-center gap-[3.75rem] shrink-0">
-          {menuConfigs.map(({ label, key, urlFn }) => (
+          {menuConfigs.map(({ label, key, urlFn, isDirectLink }) => (
             <div key={key} className="relative">
-              <button
-                onClick={() => toggleMenu(key)}
-                className={`flex items-center cursor-pointer whitespace-nowrap ${
-                  openMenu === key ? 'text-[#81D7D4]' : 'text-black'
-                }`}
-              >
-                <span className="font-normal text-[1.125rem]">{label}</span>
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className={`ml-[0.125rem] w-[1.5rem] h-[1.5rem] ${openMenu === key ? 'rotate-180' : ''}`}
-                  viewBox="0 0 24 24"
+              {isDirectLink ? (
+                <Link
+                  href="/new"
+                  className="flex items-center cursor-pointer whitespace-nowrap text-black hover:text-[#81D7D4]"
                 >
-                  <path
-                    d="M7 10L12 15L17 10"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    fill="none"
-                  />
-                </svg>
-              </button>
+                  <span className="font-normal text-[1.125rem]">{label}</span>
+                </Link>
+              ) : (
+                <button
+                  onClick={() => toggleMenu(key)}
+                  className={`flex items-center cursor-pointer whitespace-nowrap ${
+                    openMenu === key ? 'text-[#81D7D4]' : 'text-black'
+                  }`}
+                >
+                  <span className="font-normal text-[1.125rem]">{label}</span>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className={`ml-[0.125rem] w-[1.5rem] h-[1.5rem] ${openMenu === key ? 'rotate-180' : ''}`}
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 10L12 15L17 10"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      fill="none"
+                    />
+                  </svg>
+                </button>
+              )}
 
               {/* 드롭다운 */}
-              {openMenu === key && (
+              {!isDirectLink && openMenu === key && (
                 <ul className="absolute mt-[0.75rem] bg-white rounded-[0.5rem] shadow-[0_0_15px_rgba(0,0,0,0.2)] z-20">
                   {key === 'projects'
                     ? mockProjects.map((project) => (

--- a/src/components/ProfileDropdown.tsx
+++ b/src/components/ProfileDropdown.tsx
@@ -7,7 +7,7 @@ export default function ProfileDropdown() {
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="relative mt-[4px] mr-[30px]">
+    <div className="relative mt-[0.25rem] mr-[1rem]">
       {/* 프로필 아이콘 */}
       <button onClick={() => setOpen(!open)}>
         <img src="/icons/profile.svg" alt="프로필" className="cursor-pointer " />
@@ -16,21 +16,21 @@ export default function ProfileDropdown() {
       {/* 드롭다운 */}
       {open && (
         <div
-          className="absolute bg-white w-[265px] h-[100px] rounded-[8px] right-[4px] "
+          className="absolute bg-white w-[16.563rem] h-[6.25rem] rounded-[0.5rem] right-[0.25rem] "
           style={{ boxShadow: '0px 0px 15px 0px #00000033' }}
         >
           <div className="flex flex-col" onClick={() => setOpen(false)}>
             <Link href="/mypage">
-              <button className="flex mt-[13px] ml-[20px] cursor-pointer">
-                <img src="/icons/myPage-dropdown.svg" alt="마이페이지" className="mr-[12px]" />
-                <div className="text-[#505050] text-[18px]">마이페이지</div>
+              <button className="flex mt-[0.813rem] ml-[1.25rem] cursor-pointer">
+                <img src="/icons/myPage-dropdown.svg" alt="마이페이지" className="mr-[0.75rem]" />
+                <div className="text-[#505050] text-[1.125rem]">마이페이지</div>
               </button>
             </Link>
             <Link href="/login">
-              <hr className="border-[1px] border-[#BBBBBB] w-[249px] ml-[8px] mt-[6px]"></hr>
-              <button className="flex ml-[24px] mt-[12px] cursor-pointer">
-                <img src="/icons/logout.svg" alt="로그아웃" className="mr-[12px]" />
-                <div className="text-[#505050] text-[18px]">로그아웃</div>
+              <hr className="border-[0.063rem] border-[#BBBBBB] w-[15.563rem] ml-[0.5rem] mt-[0.375rem]"></hr>
+              <button className="flex ml-[1.5rem] mt-[0.75rem] cursor-pointer">
+                <img src="/icons/logout.svg" alt="로그아웃" className="mr-[0.75rem]" />
+                <div className="text-[#505050] text-[1.125rem]">로그아웃</div>
               </button>
             </Link>
           </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { usePathname, useParams } from 'next/navigation';
 import { menus } from '@/constants/menus';
-import { getHomeUrl, getNewUrl, getProjectUrl } from '../utils/url';
+import { getHomeUrl, getProjectUrl } from '../utils/url';
 import { useActiveMenu } from '@/hooks/useActiveMenu';
 
 export default function Sidebar() {
@@ -12,6 +12,11 @@ export default function Sidebar() {
   const projectId = params.projectId as string | undefined;
 
   const activeMenu = useActiveMenu();
+
+  // /new 경로에서는 사이드바 숨기기
+  if (pathname === '/new') {
+    return null;
+  }
 
   const menuItems = menus[activeMenu];
 
@@ -23,8 +28,6 @@ export default function Sidebar() {
 
           if (activeMenu === 'home') {
             href = getHomeUrl(item.path);
-          } else if (activeMenu === 'new') {
-            href = getNewUrl(item.path);
           } else if (activeMenu === 'projects') {
             href = getProjectUrl(projectId ?? '', item.path);
           }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -16,8 +16,8 @@ export default function Sidebar() {
   const menuItems = menus[activeMenu];
 
   return (
-    <aside className="w-[183px] h-full bg-[#F8F8F8] border-r-[2px] border-[#E7E7E7] flex flex-col py-[4px] px-[2px]">
-      <nav className="flex flex-col text-[18px]">
+    <aside className="w-[4.125rem] lg:w-[11.563rem] h-full bg-[#F8F8F8] border-r-[0.125rem] border-[#E7E7E7] flex flex-col py-[0.25rem] px-[0.125rem]">
+      <nav className="flex flex-col text-[1.125rem]">
         {menuItems.map((item) => {
           let href = '';
 
@@ -38,7 +38,7 @@ export default function Sidebar() {
             <Link
               key={item.name}
               href={href}
-              className={`flex items-center gap-[11px] px-[20px] py-[16px] rounded-[2px]
+              className={`flex items-center gap-0 lg:gap-[0.688rem] justify-center lg:justify-start px-[1rem] lg:px-[1.25rem] py-[1rem] rounded-[0.125rem]
                 ${isActive ? 'bg-[#81D7D4] text-white font-bold' : 'text-black hover:bg-[#E7E7E7]'}
                 transition
               `}
@@ -46,9 +46,9 @@ export default function Sidebar() {
               <img
                 src={item.icon}
                 alt=""
-                className={`w-[28px] h-[28px] ${isActive ? 'brightness-0 invert' : ''}`}
+                className={`w-[1.75rem] h-[1.75rem] ${isActive ? 'brightness-0 invert' : ''}`}
               />
-              {item.name}
+              <span className="hidden lg:inline">{item.name}</span>
             </Link>
           );
         })}

--- a/src/features/boards/MyTaskBoard.tsx
+++ b/src/features/boards/MyTaskBoard.tsx
@@ -25,9 +25,14 @@ export default function MyTaskBoard() {
   };
 
   return (
-    <div className="grid grid-cols-4 gap-x-[36px] gap-y-[60px] mt-[60px] px-[35px]">
+    <div
+      className="grid [grid-template-columns:repeat(2,325px)] lg:[grid-template-columns:repeat(4,325px)] gap-x-[36px] gap-y-[80px] mt-[60px] min-w-[1024px] overflow-x-auto"
+      style={{
+        paddingLeft: 'clamp(43px, calc(112px - ((100vw - 1024px) * 0.077)), 112px)',
+      }}
+    >
       {filteredProjects.map((project) => (
-        <div key={project.id} className="flex flex-col">
+        <div key={project.id}>
           <ProjectHeader
             projectName={project.name}
             isOpen={openProjectIds.includes(project.id)}

--- a/src/features/boards/MyTaskBoard.tsx
+++ b/src/features/boards/MyTaskBoard.tsx
@@ -26,7 +26,7 @@ export default function MyTaskBoard() {
 
   return (
     <div
-      className="grid [grid-template-columns:repeat(2,325px)] lg:[grid-template-columns:repeat(4,325px)] gap-x-[36px] gap-y-[80px] mt-[60px] min-w-[1024px] overflow-x-auto"
+      className="grid [grid-template-columns:repeat(2,20.313rem)] lg:[grid-template-columns:repeat(4,20.313rem)] gap-x-[2.25rem] gap-y-[5rem] mt-[3.75rem] min-w-[64rem] overflow-x-auto"
       style={{
         paddingLeft: 'clamp(43px, calc(112px - ((100vw - 1024px) * 0.077)), 112px)',
       }}
@@ -39,7 +39,7 @@ export default function MyTaskBoard() {
             onToggle={() => handleToggle(project.id)}
           />
           {openProjectIds.includes(project.id) && (
-            <div className="flex flex-col gap-3 mt-6">
+            <div className="flex flex-col gap-3 mt-[1.5rem]">
               {project.myTasks.map((task) => (
                 <TaskItem
                   key={task.id}

--- a/src/features/boards/components/ProjectHeader.tsx
+++ b/src/features/boards/components/ProjectHeader.tsx
@@ -6,14 +6,15 @@ interface ProjectHeaderProps {
 
 export default function ProjectHeader({ projectName, isOpen, onToggle }: ProjectHeaderProps) {
   return (
-    <button onClick={onToggle} className="cursor-pointer">
-      <div className="flex bg-[#DAF3F3] w-[325px] h-[68px] items-center justify-between rounded-[8px]">
-        <span className="font-medium text-[18px] mx-auto">{projectName}</span>
-        <img
-          src="/icons/arrow-down.svg"
-          className={`w-[32px] h-[32px] mr-[4px] ${isOpen ? 'rotate-180' : ''}`}
-        />
-      </div>
+    <button
+      onClick={onToggle}
+      className="cursor-pointer flex bg-[#DAF3F3] w-[325px] h-[68px] items-center justify-between rounded-[8px]"
+    >
+      <span className="font-medium text-[18px] mx-auto">{projectName}</span>
+      <img
+        src="/icons/arrow-down.svg"
+        className={`w-[32px] h-[32px] mr-[4px] ${isOpen ? 'rotate-180' : ''}`}
+      />
     </button>
   );
 }

--- a/src/features/boards/components/ProjectHeader.tsx
+++ b/src/features/boards/components/ProjectHeader.tsx
@@ -8,12 +8,12 @@ export default function ProjectHeader({ projectName, isOpen, onToggle }: Project
   return (
     <button
       onClick={onToggle}
-      className="cursor-pointer flex bg-[#DAF3F3] w-[325px] h-[68px] items-center justify-between rounded-[8px]"
+      className="cursor-pointer flex bg-[#DAF3F3] w-[20.313rem] h-[4.25rem] items-center justify-between rounded-[0.5rem]"
     >
-      <span className="font-medium text-[18px] mx-auto">{projectName}</span>
+      <span className="font-medium text-[1.125rem] mx-auto">{projectName}</span>
       <img
         src="/icons/arrow-down.svg"
-        className={`w-[32px] h-[32px] mr-[4px] ${isOpen ? 'rotate-180' : ''}`}
+        className={`w-[2rem] h-[2rem] mr-[0.25rem] ${isOpen ? 'rotate-180' : ''}`}
       />
     </button>
   );

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,6 +1,4 @@
 export const getHomeUrl = (path = '') => `/home${path ? `/${path}` : ''}`;
 
-export const getNewUrl = (path = '') => `/new${path ? `/${path}` : ''}`;
-
 export const getProjectUrl = (projectId: string, path = '') =>
   `/projects/${projectId}${path ? `/${path}` : ''}`;


### PR DESCRIPTION
## 연관 이슈
- Closes #44 

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
- 처음에는 해상도가 줄어들 때 전체 화면에 대한 가로 스크롤이 생기도록 했었는데, 그러다보니 마이페이지 이모티콘 우측 여백이 길어지길래 내부 페이지에 대한 스크롤로 변경했습니다. (아래 캡쳐 이미지 첨부)
<img width="2045" height="621" alt="image" src="https://github.com/user-attachments/assets/c4044464-20fe-4dfe-a39c-a7c98f3a5192" />

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- layout에서 설정한 여백이 24px~120px인데 업무 태스크 여백이 136px~163px이라 clamp 함수로 해당 컴포넌트의 여백을 112px~43px으로 설정했습니다. 다만 이 과정에서 rem으로 변환했을 때 무슨 이유에선지 여백이 제대로 조정되지 않아 해당 함수만 우선 단위를 px로 두었습니다.

## 첨부 자료
-
