### PR TITLE
[Feat/53] 업무 대시보드 페이지 반응형 UI 구현

### DIFF
--- a/src/app/(main)/projects/[projectId]/dashboard/page.tsx
+++ b/src/app/(main)/projects/[projectId]/dashboard/page.tsx
@@ -20,8 +20,11 @@ export default function DashboardPage() {
 
   return (
     <div className="min-h-screen w-full bg-white flex flex-col">
-      <header className="flex items-center justify-between pb-[16px] px-[8px] border-b-[2px] border-[#E7E7E7]">
-        <h1 className="text-[24px] font-bold">업무 대시보드</h1>
+      <header className="flex items-center justify-between pb-[1rem] px-[0.5rem] border-b-[0.125rem] border-[#E7E7E7]">
+        <h1 className="lg:text-[1.5rem] text-[1.375rem] lg:font-bold font-semibold">
+          업무 대시보드
+        </h1>
+        <div className="flex-1 flex justify-end"></div>
         <Searchbar
           placeholder="검색어를 입력하세요."
           onChange={() => {}}
@@ -37,9 +40,9 @@ export default function DashboardPage() {
 
       <main className="flex-1 overflow-x-auto">
         <div
-          className="min-w-[64rem]"
+          className="min-w-[40rem]"
           style={{
-            paddingLeft: 'clamp(43px, calc(112px - ((100vw - 1024px) * 0.077)), 112px)',
+            paddingLeft: 'clamp(2.688rem, calc(7rem - ((100vw - 64rem) * 0.077)), 7rem)',
           }}
         >
           {isStepView ? (

--- a/src/app/(main)/projects/[projectId]/dashboard/page.tsx
+++ b/src/app/(main)/projects/[projectId]/dashboard/page.tsx
@@ -36,11 +36,18 @@ export default function DashboardPage() {
       />
 
       <main className="flex-1 overflow-x-auto">
-        {isStepView ? (
-          <StepsBoard steps={steps} projectId={projectId} />
-        ) : (
-          <StatusBoard steps={steps} projectId={projectId} />
-        )}
+        <div
+          className="min-w-[64rem]"
+          style={{
+            paddingLeft: 'clamp(43px, calc(112px - ((100vw - 1024px) * 0.077)), 112px)',
+          }}
+        >
+          {isStepView ? (
+            <StepsBoard steps={steps} projectId={projectId} />
+          ) : (
+            <StatusBoard steps={steps} projectId={projectId} />
+          )}
+        </div>
       </main>
     </div>
   );

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -11,17 +11,20 @@ export function Searchbar({
 }: SearchbarProps) {
   return (
     <div className="flex items-center gap-3">
-      <div className="w-[332px] h-[39px] flex items-center px-[10px] py-[6px] justify-between bg-[#E7E7E7] rounded-[4px]">
+      <div className="w-[17.5rem] h-[2rem] lg:w-[20.75rem] lg:h-[2.438rem] flex items-center px-[0.625rem] py-[0.375rem] justify-between bg-[#E7E7E7] rounded-[0.25rem]">
         <input
           type="text"
           placeholder={placeholder}
-          className="rounded text-[18px] pl-[2px] text-[#898989]"
+          className="rounded text-[1.125rem] pl-[0.125rem] text-[#898989]"
           onChange={onChange}
         />
-        <img src="/icons/search.svg" className="w-[28px] h-[28px]" />
+        <img
+          src="/icons/search.svg"
+          className="w-[1.5rem] h-[1.5rem] lg:w-[1.75rem] lg:h-[1.75rem]"
+        />
       </div>
       <button onClick={onFilterClick}>
-        <img src="/icons/filter.svg" className="w-[32px] h-[32px]" />
+        <img src="/icons/filter.svg" className="w-[2rem] h-[2rem]" />
       </button>
     </div>
   );

--- a/src/components/ToggleButton.tsx
+++ b/src/components/ToggleButton.tsx
@@ -21,7 +21,7 @@ export default function ToggleButton({ leftLabel, rightLabel, onToggle }: Toggle
       <div className="flex items-center mt-[20px] p-[4px] bg-[#F8F8F8] border border-[#E7E7E7] rounded-[4px]">
         <button
           onClick={() => handleToggle(true)}
-          className={`relative px-4 py-1 rounded text-[18px] text-center ${
+          className={`cursor-pointer relative px-4 py-1 rounded text-[18px] text-center ${
             isLeftSelected ? 'bg-[#81D7D4] text-white font-bold' : 'bg-[#F8F8F8] text-gray-700'
           }`}
         >
@@ -31,7 +31,7 @@ export default function ToggleButton({ leftLabel, rightLabel, onToggle }: Toggle
 
         <button
           onClick={() => handleToggle(false)}
-          className={`relative px-4 py-1 rounded text-[18px] text-center ${
+          className={`cursor-pointer relative px-4 py-1 rounded text-[18px] text-center ${
             !isLeftSelected ? 'bg-[#81D7D4] text-white font-bold' : 'bg-[#F8F8F8] text-gray-700'
           }`}
         >

--- a/src/features/boards/StatusBoard.tsx
+++ b/src/features/boards/StatusBoard.tsx
@@ -6,14 +6,14 @@ export default function StatusBoard({ steps, projectId }: BoardProps) {
   const allTasks = steps.flatMap((step) => step.items);
 
   return (
-    <div className="flex gap-[80px] mt-[60px] ml-[35px]">
+    <div className="grid [grid-template-columns:repeat(2,20.313rem)] lg:[grid-template-columns:repeat(4,20.313rem)] gap-x-[2.25rem] gap-y-[5rem] mt-[3.75rem]">
       {STATUS_ORDER.map(({ status, color }) => {
         const tasksByStatus = allTasks.filter((task) => task.status === status);
 
         return (
           <div key={status} className="flex flex-col">
             <div
-              className="w-[325px] h-[46px] flex items-center justify-center rounded-[8px] font-medium text-[18px]"
+              className="w-full h-[46px] flex items-center justify-center rounded-[8px] font-medium text-[18px]"
               style={{ backgroundColor: color }}
             >
               {status}

--- a/src/features/boards/StatusBoard.tsx
+++ b/src/features/boards/StatusBoard.tsx
@@ -13,7 +13,7 @@ export default function StatusBoard({ steps, projectId }: BoardProps) {
         return (
           <div key={status} className="flex flex-col">
             <div
-              className="w-full h-[46px] flex items-center justify-center rounded-[8px] font-medium text-[18px]"
+              className="w-full h-[2.875rem] flex items-center justify-center rounded-[0.5rem] font-medium text-[1.125rem]"
               style={{ backgroundColor: color }}
             >
               {status}

--- a/src/features/boards/StepsBoard.tsx
+++ b/src/features/boards/StepsBoard.tsx
@@ -59,7 +59,7 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
                   <div
                     ref={provided.innerRef}
                     {...provided.droppableProps}
-                    className="flex flex-col mt-6 min-h-[10px]"
+                    className="flex flex-col mt-6 min-h-[0.625rem]"
                   >
                     {/* 각 TaskItem은 드래그 가능한 아이템 (Draggable) */}
                     {step.items.map((task, idx) => (
@@ -81,8 +81,8 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
                             className={`mb-3 last:mb-0 ${snapshot.isDragging ? 'opacity-50' : ''}`}
                             style={{
                               ...provided.draggableProps.style,
-                              width: '325px',
-                              height: '122px',
+                              width: '100%',
+                              height: '7.625rem',
                             }}
                           >
                             <div {...provided.dragHandleProps}>
@@ -113,7 +113,7 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
         ))}
         <button
           onClick={addStep}
-          className="flex bg-[#F8F8F8] text-[#898989] w-[325px] h-[68px] items-center justify-center rounded-[8px] font-medium text-[18px] cursor-pointer hover:bg-[#F0F0F0] transition-colors duration-200"
+          className="flex bg-[#F8F8F8] text-[#898989] w-full h-[4.25rem] items-center justify-center rounded-[0.5rem] font-medium text-[1.125rem] cursor-pointer hover:bg-[#F0F0F0] transition-colors duration-200"
         >
           + STEP 추가
         </button>

--- a/src/features/boards/StepsBoard.tsx
+++ b/src/features/boards/StepsBoard.tsx
@@ -38,7 +38,7 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
   return (
     // 전체 드래그앤드롭 컨텍스트 - 모든 드래그앤드롭 이벤트를 관리
     <DragDropContext onDragEnd={onDragEnd}>
-      <div className="grid grid-cols-4 gap-x-[36px] gap-y-[60px] mt-[60px] px-[35px]">
+      <div className="grid [grid-template-columns:repeat(2,20.313rem)] lg:[grid-template-columns:repeat(4,20.313rem)] gap-x-[2.25rem] gap-y-[5rem] mt-[3.75rem]">
         {localSteps.map((step) => (
           <div key={step.id} className="flex flex-col">
             <StepHeader

--- a/src/features/boards/components/AddTaskButton.tsx
+++ b/src/features/boards/components/AddTaskButton.tsx
@@ -11,7 +11,7 @@ export default function AddTaskButton({ stepName, className = '' }: AddTaskButto
 
   return (
     <button
-      className={`flex bg-[#FFFFFF] text-[#898989] w-[325px] h-[44px] items-center justify-center rounded-[8px] text-[16px] cursor-pointer border border-[#BBBBBB] border-[1.5px] ${className}`}
+      className={`flex bg-[#FFFFFF] text-[#898989] w-[20.313rem] h-[2.75rem] items-center justify-center rounded-[0.5rem] text-[1rem] cursor-pointer border border-[#BBBBBB] border-[0.094rem] ${className}`}
       onClick={handleClick}
     >
       + 업무 추가

--- a/src/features/boards/components/StepHeader.tsx
+++ b/src/features/boards/components/StepHeader.tsx
@@ -29,11 +29,11 @@ export default function StepHeader({
       onMouseLeave={() => setIsHovered(false)}
     >
       <button onClick={onToggle} className="cursor-pointer w-full">
-        <div className="flex bg-[#DAF3F3] w-[325px] h-[68px] items-center justify-between rounded-[8px]">
-          <span className="font-medium text-[18px] mx-auto">{stepName}</span>
+        <div className="flex bg-[#DAF3F3] w-full h-[4.25rem] items-center justify-between rounded-[0.5rem]">
+          <span className="font-medium text-[1.125rem] mx-auto">{stepName}</span>
           {showDelete && isHovered ? (
             <span
-              className="w-[32px] h-[32px] mr-[4px] flex items-center justify-center"
+              className="w-[2rem] h-[2rem] mr-[0.25rem] flex items-center justify-center"
               onClick={handleIconClick}
               role="button"
               tabIndex={0}
@@ -46,7 +46,7 @@ export default function StepHeader({
           ) : (
             <img
               src="/icons/arrow-down.svg"
-              className={`w-[32px] h-[32px] mr-[4px] ${isOpen ? 'rotate-180' : ''}`}
+              className={`w-[2rem] h-[2rem] mr-[0.25rem] ${isOpen ? 'rotate-180' : ''}`}
             />
           )}
         </div>


### PR DESCRIPTION
## 연관 이슈
- Closes #53

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [x] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [x] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
- 나의 업무와 같이 업무 대시보드 페이지도 반응형 UI 구현했습니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 현재 해당 페이지 확인해보시면 검색창이 밀리는 현상이 있습니다. clamp 함수로 인해 <main> 요소의 패딩이 커지면서 헤더도 같이 늘어나 navbar와의 크기 차이가 생겨서 그렇게 됐는데, 수정 방향을 아직 고민 중입니다. 추후에 수정하도록 하겠습니다.

## 첨부 자료
-
