### PR TITLE
[Feat/79] 프로젝트 참여 페이지 UI 구현 및 API 연동

### DIFF
--- a/src/app/(main)/new/page.tsx
+++ b/src/app/(main)/new/page.tsx
@@ -12,7 +12,11 @@ export default function New() {
   const createProjectMutation = useCreateProject(
     (response) => {
       if (response.isSuccess) {
-        setInviteCode(response.result.inviteCode);
+        // 서버에서 전체 URL을 받으므로 inviteCode 부분만 추출
+        const fullUrl = response.result.inviteCode;
+        const inviteCodeMatch = fullUrl.match(/\/join\/([^\/]+)$/);
+        const extractedInviteCode = inviteCodeMatch ? inviteCodeMatch[1] : fullUrl;
+        setInviteCode(extractedInviteCode);
         setInviteVisible(true);
       }
     },
@@ -37,7 +41,7 @@ export default function New() {
     const textToCopy = `💡 프로젝트에 참여해 주세요!
 아래 링크를 통해 참여를 수락하면, 
 바로 협업을 시작할 수 있어요.
-👉 참여 코드: ${inviteCode}
+👉 참여 링크: ${window.location.origin}/projects/join/${inviteCode}
 링크 유효기간: 7일까지`;
 
     try {
@@ -105,7 +109,10 @@ export default function New() {
                   아래 링크를 통해 참여를 수락하면, <br />
                   바로 협업을 시작할 수 있어요.
                   <br />
-                  👉 참여 코드: <span className="font-bold text-[#81D7D4]">{inviteCode}</span>
+                  👉 참여 링크:{' '}
+                  <span className="font-bold text-[#81D7D4]">
+                    {window.location.origin}/projects/join/{inviteCode}
+                  </span>
                   <br />
                   링크 유효기간: 7일까지
                 </p>

--- a/src/app/(main)/projects/join/[inviteCode]/page.tsx
+++ b/src/app/(main)/projects/join/[inviteCode]/page.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useJoinProject } from '@/hooks/mutations/useJoinProject';
+
+export default function JoinProject() {
+  const params = useParams();
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [projectInfo, setProjectInfo] = useState<any>(null);
+  const [isExpired, setIsExpired] = useState(false);
+  const [teamLeaderName, setTeamLeaderName] = useState<string>('');
+  const [showWelcomeModal, setShowWelcomeModal] = useState(false);
+
+  const inviteCode = params.inviteCode as string;
+
+  const joinProjectMutation = useJoinProject(
+    (response) => {
+      if (response.isSuccess) {
+        const projectId = response.result.project.id;
+        const projectName = response.result.project.name;
+
+        // 팀장 정보 찾기 (permission이 LEAD인 사용자)
+        const leader = response.result.users.find((user) => user.permission === 'LEAD');
+        const leaderName = leader?.name || '팀장';
+
+        setProjectInfo({
+          name: projectName,
+          projectId: projectId,
+        });
+        setTeamLeaderName(leaderName);
+        setShowWelcomeModal(true);
+        setIsLoading(false);
+
+        // 2초 후 프로젝트 페이지로 이동
+        setTimeout(() => {
+          router.push(`/projects/${projectId}`);
+        }, 2000);
+      } else {
+        // 에러 코드에 따라 만료 여부 판단
+        if (response.error?.errorCode === 'INVALID_INVITE_CODE') {
+          setIsExpired(true);
+          setTeamLeaderName('팀장');
+        } else {
+          setError(response.error?.reason || '프로젝트 참여에 실패했습니다.');
+        }
+        setIsLoading(false);
+      }
+    },
+    (error) => {
+      setError('프로젝트 참여에 실패했습니다. 초대 링크를 다시 확인해주세요.');
+      setIsLoading(false);
+    }
+  );
+
+  const handleAccept = () => {
+    setIsLoading(true);
+    setError(null);
+    joinProjectMutation.mutate(inviteCode);
+  };
+
+  // 유효기간 만료 상태
+  if (isExpired) {
+    return (
+      <div className="min-h-screen w-full bg-white flex items-center justify-center">
+        <div className="flex flex-col items-center gap-4 p-8 text-center">
+          <h1 className="text-xl text-gray-800 mb-2">유효기간이 만료된 링크입니다.</h1>
+          <p className="text-lg text-gray-600">
+            {teamLeaderName}에게 새로운 링크를 요청 후, 프로젝트에 참여해주세요.
+          </p>
+          <button
+            onClick={() => router.push('/home')}
+            className="mt-6 px-6 py-3 bg-[#81D7D4] text-white rounded-lg hover:bg-[#6BC7C4] font-medium"
+          >
+            홈으로 돌아가기
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // 일반 에러 상태
+  if (error) {
+    return (
+      <div className="min-h-screen w-full bg-white flex items-center justify-center">
+        <div className="flex flex-col items-center gap-4 p-8">
+          <div className="text-red-500 text-xl mb-4">❌</div>
+          <p className="text-lg text-gray-800 text-center">{error}</p>
+          <button
+            onClick={() => router.push('/home')}
+            className="mt-4 px-6 py-2 bg-[#81D7D4] text-white rounded-lg hover:bg-[#6BC7C4]"
+          >
+            홈으로 돌아가기
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // 정상 초대 상태
+  return (
+    <div className="min-h-screen w-full bg-white flex items-center justify-center">
+      <div className="flex flex-col items-center gap-6 p-8 text-center">
+        <h1 className="text-2xl font-bold text-gray-800">프로젝트에 참여하시겠습니까?</h1>
+        <p className="text-lg text-gray-600">팀장님이 함께 프로젝트를 진행하고 싶어해요!</p>
+        <button
+          onClick={handleAccept}
+          disabled={isLoading}
+          className={`px-8 py-3 text-white rounded-lg font-medium text-lg ${
+            isLoading ? 'bg-gray-400 cursor-not-allowed' : 'bg-[#81D7D4] hover:bg-[#6BC7C4]'
+          }`}
+        >
+          {isLoading ? '처리 중...' : '수락'}
+        </button>
+      </div>
+
+      {/* 환영 모달 */}
+      {showWelcomeModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-8 max-w-md w-full mx-4 shadow-lg">
+            <div className="flex flex-col items-center gap-4 text-center">
+              {/* 아이콘 placeholder */}
+              <div className="w-16 h-16 bg-gray-300 rounded-lg flex items-center justify-center">
+                <span className="text-gray-600 text-2xl">🎉</span>
+              </div>
+
+              <h2 className="text-xl font-bold text-gray-800">환영합니다!</h2>
+
+              <p className="text-lg text-gray-600">{projectInfo?.name}의 팀원이 되셨습니다.</p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(main)/projects/join/[inviteCode]/page.tsx
+++ b/src/app/(main)/projects/join/[inviteCode]/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { useGetProject } from '@/hooks/queries/useGetProject';
 import { useJoinProject } from '@/hooks/mutations/useJoinProject';
 
 export default function JoinProject() {
@@ -10,27 +11,23 @@ export default function JoinProject() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [projectInfo, setProjectInfo] = useState<any>(null);
-  const [isExpired, setIsExpired] = useState(false);
-  const [teamLeaderName, setTeamLeaderName] = useState<string>('');
   const [showWelcomeModal, setShowWelcomeModal] = useState(false);
 
   const inviteCode = params.inviteCode as string;
 
+  // 1. GET 요청으로 초대코드 유효성 확인
+  const getProjectQuery = useGetProject({ inviteCode });
+
+  // 2. POST 요청으로 프로젝트 참여
   const joinProjectMutation = useJoinProject(
     (response) => {
       if (response.isSuccess) {
-        const projectId = response.result.project.id;
-        const projectName = response.result.project.name;
-
-        // 팀장 정보 찾기 (permission이 LEAD인 사용자)
-        const leader = response.result.users.find((user) => user.permission === 'LEAD');
-        const leaderName = leader?.name || '팀장';
+        const { projectId, projectName } = response.result;
 
         setProjectInfo({
           name: projectName,
           projectId: projectId,
         });
-        setTeamLeaderName(leaderName);
         setShowWelcomeModal(true);
         setIsLoading(false);
 
@@ -39,49 +36,44 @@ export default function JoinProject() {
           router.push(`/projects/${projectId}`);
         }, 2000);
       } else {
-        // 에러 코드에 따라 만료 여부 판단
-        if (response.error?.errorCode === 'INVALID_INVITE_CODE') {
-          setIsExpired(true);
-          setTeamLeaderName('팀장');
-        } else {
-          setError(response.error?.reason || '프로젝트 참여에 실패했습니다.');
-        }
+        setError(response.error || '프로젝트 참여에 실패했습니다.');
         setIsLoading(false);
       }
     },
     (error) => {
+      console.error('프로젝트 참여 오류:', error);
       setError('프로젝트 참여에 실패했습니다. 초대 링크를 다시 확인해주세요.');
       setIsLoading(false);
     }
   );
 
+  // GET 요청 결과 처리
+  useEffect(() => {
+    if (getProjectQuery.isError) {
+      console.error('초대코드 유효성 확인 오류:', getProjectQuery.error);
+      router.push('/home/tasks');
+    }
+  }, [getProjectQuery.isError, getProjectQuery.error, router]);
+
   const handleAccept = () => {
     setIsLoading(true);
     setError(null);
-    joinProjectMutation.mutate(inviteCode);
+    joinProjectMutation.mutate({ inviteCode });
   };
 
-  // 유효기간 만료 상태
-  if (isExpired) {
+  // 로딩 상태
+  if (getProjectQuery.isLoading) {
     return (
       <div className="min-h-screen w-full bg-white flex items-center justify-center">
         <div className="flex flex-col items-center gap-4 p-8 text-center">
-          <h1 className="text-xl text-gray-800 mb-2">유효기간이 만료된 링크입니다.</h1>
-          <p className="text-lg text-gray-600">
-            {teamLeaderName}에게 새로운 링크를 요청 후, 프로젝트에 참여해주세요.
-          </p>
-          <button
-            onClick={() => router.push('/home')}
-            className="mt-6 px-6 py-3 bg-[#81D7D4] text-white rounded-lg hover:bg-[#6BC7C4] font-medium"
-          >
-            홈으로 돌아가기
-          </button>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#81D7D4]"></div>
+          <p className="text-lg text-gray-600">초대 링크를 확인하고 있습니다...</p>
         </div>
       </div>
     );
   }
 
-  // 일반 에러 상태
+  // 에러 상태
   if (error) {
     return (
       <div className="min-h-screen w-full bg-white flex items-center justify-center">
@@ -89,7 +81,7 @@ export default function JoinProject() {
           <div className="text-red-500 text-xl mb-4">❌</div>
           <p className="text-lg text-gray-800 text-center">{error}</p>
           <button
-            onClick={() => router.push('/home')}
+            onClick={() => router.push('/home/tasks')}
             className="mt-4 px-6 py-2 bg-[#81D7D4] text-white rounded-lg hover:bg-[#6BC7C4]"
           >
             홈으로 돌아가기
@@ -121,13 +113,10 @@ export default function JoinProject() {
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
           <div className="bg-white rounded-lg p-8 max-w-md w-full mx-4 shadow-lg">
             <div className="flex flex-col items-center gap-4 text-center">
-              {/* 아이콘 placeholder */}
               <div className="w-16 h-16 bg-gray-300 rounded-lg flex items-center justify-center">
                 <span className="text-gray-600 text-2xl">🎉</span>
               </div>
-
               <h2 className="text-xl font-bold text-gray-800">환영합니다!</h2>
-
               <p className="text-lg text-gray-600">{projectInfo?.name}의 팀원이 되셨습니다.</p>
             </div>
           </div>

--- a/src/app/(main)/projects/join/[inviteCode]/page.tsx
+++ b/src/app/(main)/projects/join/[inviteCode]/page.tsx
@@ -22,18 +22,12 @@ export default function JoinProject() {
   const joinProjectMutation = useJoinProject(
     (response) => {
       if (response.isSuccess) {
-        const { projectId, projectName } = response.result;
-
-        setProjectInfo({
-          name: projectName,
-          projectId: projectId,
-        });
         setShowWelcomeModal(true);
         setIsLoading(false);
 
         // 2초 후 프로젝트 페이지로 이동
         setTimeout(() => {
-          router.push(`/projects/${projectId}`);
+          router.push(`/projects/${projectInfo.projectId}`);
         }, 2000);
       } else {
         setError(response.error || '프로젝트 참여에 실패했습니다.');
@@ -49,11 +43,45 @@ export default function JoinProject() {
 
   // GET 요청 결과 처리
   useEffect(() => {
-    if (getProjectQuery.isError) {
+    if (getProjectQuery.isSuccess && getProjectQuery.data) {
+      // 프로젝트 정보 설정
+      const projectData = getProjectQuery.data.result;
+      if (projectData.project) {
+        setProjectInfo({
+          name: projectData.project.name,
+          projectId: projectData.project.id,
+        });
+      }
+    } else if (getProjectQuery.isError) {
       console.error('초대코드 유효성 확인 오류:', getProjectQuery.error);
-      router.push('/home/tasks');
+
+      // 에러 응답에서 errorCode를 확인하여 처리 방식 결정
+      const errorResponse = getProjectQuery.error as any;
+      const errorCode = errorResponse?.response?.data?.error?.errorCode;
+      const errorReason = errorResponse?.response?.data?.error?.reason;
+
+      if (errorCode === 'ALREADY_JOINED') {
+        // 이미 참여한 프로젝트 - result에서 projectId를 추출하여 프로젝트 홈으로 리다이렉트
+        const projectId = errorResponse?.response?.data?.result?.projectId;
+        if (projectId) {
+          console.log('이미 참여한 프로젝트입니다. 프로젝트 홈으로 이동합니다.');
+          router.push(`/projects/${projectId}`);
+        } else {
+          console.error('projectId가 없습니다.');
+          router.push('/home/tasks');
+        }
+      } else {
+        // NOT_EXISTS 또는 CODE_EXPIRED - 에러 상태로 설정하여 에러 화면 표시
+        setError(errorReason || '초대 링크가 유효하지 않습니다.');
+      }
     }
-  }, [getProjectQuery.isError, getProjectQuery.error, router]);
+  }, [
+    getProjectQuery.isSuccess,
+    getProjectQuery.data,
+    getProjectQuery.isError,
+    getProjectQuery.error,
+    router,
+  ]);
 
   const handleAccept = () => {
     setIsLoading(true);
@@ -61,31 +89,19 @@ export default function JoinProject() {
     joinProjectMutation.mutate({ inviteCode });
   };
 
-  // 로딩 상태
   if (getProjectQuery.isLoading) {
-    return (
-      <div className="min-h-screen w-full bg-white flex items-center justify-center">
-        <div className="flex flex-col items-center gap-4 p-8 text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#81D7D4]"></div>
-          <p className="text-lg text-gray-600">초대 링크를 확인하고 있습니다...</p>
-        </div>
-      </div>
-    );
+    return null;
   }
 
-  // 에러 상태
+  // 에러 상태 (잘못된 코드 또는 만료된 코드)
   if (error) {
     return (
       <div className="min-h-screen w-full bg-white flex items-center justify-center">
         <div className="flex flex-col items-center gap-4 p-8">
-          <div className="text-red-500 text-xl mb-4">❌</div>
           <p className="text-lg text-gray-800 text-center">{error}</p>
-          <button
-            onClick={() => router.push('/home/tasks')}
-            className="mt-4 px-6 py-2 bg-[#81D7D4] text-white rounded-lg hover:bg-[#6BC7C4]"
-          >
-            홈으로 돌아가기
-          </button>
+          <p className="text-lg text-gray-800 text-center">
+            팀장에게 새로운 링크를 요청 후, 프로젝트에 참여해주세요.
+          </p>
         </div>
       </div>
     );
@@ -96,7 +112,9 @@ export default function JoinProject() {
     <div className="min-h-screen w-full bg-white flex items-center justify-center">
       <div className="flex flex-col items-center gap-6 p-8 text-center">
         <h1 className="text-2xl font-bold text-gray-800">프로젝트에 참여하시겠습니까?</h1>
-        <p className="text-lg text-gray-600">팀장님이 함께 프로젝트를 진행하고 싶어해요!</p>
+        <p className="text-lg text-gray-600">
+          {projectInfo.projectLeader}님이 함께 프로젝트를 진행하고 싶어해요!
+        </p>
         <button
           onClick={handleAccept}
           disabled={isLoading}
@@ -104,7 +122,7 @@ export default function JoinProject() {
             isLoading ? 'bg-gray-400 cursor-not-allowed' : 'bg-[#81D7D4] hover:bg-[#6BC7C4]'
           }`}
         >
-          {isLoading ? '처리 중...' : '수락'}
+          수락
         </button>
       </div>
 

--- a/src/hooks/mutations/useJoinProject.ts
+++ b/src/hooks/mutations/useJoinProject.ts
@@ -1,0 +1,14 @@
+import { useMutation } from '@tanstack/react-query';
+import { getJoinProject } from '@/services/projects/joinProject';
+import { JoinProjectResponse } from '@/types/api/project';
+
+export const useJoinProject = (
+  onSuccess?: (response: JoinProjectResponse) => void,
+  onError?: (error: any) => void
+) => {
+  return useMutation({
+    mutationFn: getJoinProject,
+    onSuccess,
+    onError,
+  });
+};

--- a/src/hooks/mutations/useJoinProject.ts
+++ b/src/hooks/mutations/useJoinProject.ts
@@ -1,13 +1,13 @@
 import { useMutation } from '@tanstack/react-query';
-import { getJoinProject } from '@/services/projects/joinProject';
-import { JoinProjectResponse } from '@/types/api/project';
+import { postJoinProject } from '@/services/projects/useProject';
+import { PostJoinProjectResponse } from '@/types/api/project';
 
 export const useJoinProject = (
-  onSuccess?: (response: JoinProjectResponse) => void,
+  onSuccess?: (response: PostJoinProjectResponse) => void,
   onError?: (error: any) => void
 ) => {
   return useMutation({
-    mutationFn: getJoinProject,
+    mutationFn: postJoinProject,
     onSuccess,
     onError,
   });

--- a/src/hooks/queries/useGetProject.ts
+++ b/src/hooks/queries/useGetProject.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getJoinProject } from '@/services/projects/useProject';
+import { GetJoinProjectRequest, GetJoinProjectResponse } from '@/types/api/project';
+
+export const useGetProject = (params: GetJoinProjectRequest) => {
+  return useQuery({
+    queryKey: ['getProject', params.inviteCode],
+    queryFn: () => getJoinProject(params),
+    enabled: !!params.inviteCode,
+  });
+};

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -4,10 +4,29 @@ import axios from 'axios';
 
 const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
-  withCredentials: true,
+  withCredentials: true, // 쿠키 기반 인증을 위해 필수적인 옵션입니다.
   headers: {
     'Content-Type': 'application/json',
   },
 });
+
+// Response interceptor - 401 에러(인증 실패) 시 로그인 페이지로 리다이렉트
+axiosInstance.interceptors.response.use(
+  (response) => {
+    // 2xx 범위의 상태 코드는 이 함수를 트리거합니다.
+    return response;
+  },
+  (error) => {
+    // 2xx 외의 상태 코드는 이 함수를 트리거합니다.
+    if (typeof window !== 'undefined' && error.response?.status === 401) {
+      // 현재 요청이 로그인 페이지로 향하는 것을 방지하여 무한 리다이렉트를 막습니다.
+      if (window.location.pathname !== '/login') {
+        console.error('401 Unauthorized. 로그인 페이지로 이동합니다.');
+        window.location.href = '/login';
+      }
+    }
+    return Promise.reject(error);
+  }
+);
 
 export default axiosInstance;

--- a/src/services/projects/createProject.ts
+++ b/src/services/projects/createProject.ts
@@ -1,9 +1,0 @@
-import axiosInstance from '@/lib/axiosInstance';
-import { CreateProjectRequest, CreateProjectReponse } from '@/types/api/project';
-
-export const postCreateProject = async (
-  body: CreateProjectRequest
-): Promise<CreateProjectReponse> => {
-  const { data } = await axiosInstance.post<CreateProjectReponse>('/api/v1/projects', body);
-  return data;
-};

--- a/src/services/projects/joinProject.ts
+++ b/src/services/projects/joinProject.ts
@@ -1,9 +1,0 @@
-import axiosInstance from '@/lib/axiosInstance';
-import { JoinProjectResponse } from '@/types/api/project';
-
-export const getJoinProject = async (inviteCode: string): Promise<JoinProjectResponse> => {
-  const { data } = await axiosInstance.get<JoinProjectResponse>(
-    `/api/v1/projects/join?inviteCode=${inviteCode}`
-  );
-  return data;
-};

--- a/src/services/projects/joinProject.ts
+++ b/src/services/projects/joinProject.ts
@@ -1,0 +1,9 @@
+import axiosInstance from '@/lib/axiosInstance';
+import { JoinProjectResponse } from '@/types/api/project';
+
+export const getJoinProject = async (inviteCode: string): Promise<JoinProjectResponse> => {
+  const { data } = await axiosInstance.get<JoinProjectResponse>(
+    `/api/v1/projects/join?inviteCode=${inviteCode}`
+  );
+  return data;
+};

--- a/src/services/projects/useProject.ts
+++ b/src/services/projects/useProject.ts
@@ -1,0 +1,35 @@
+import axiosInstance from '@/lib/axiosInstance';
+import {
+  CreateProjectRequest,
+  CreateProjectReponse,
+  GetJoinProjectRequest,
+  GetJoinProjectResponse,
+  PostJoinProjectRequest,
+  PostJoinProjectResponse,
+} from '@/types/api/project';
+
+// 프로젝트 생성
+export const postCreateProject = async (
+  body: CreateProjectRequest
+): Promise<CreateProjectReponse> => {
+  const { data } = await axiosInstance.post<CreateProjectReponse>('/api/v1/projects', body);
+  return data;
+};
+
+// 초대코드 유효성 확인 (GET)
+export const getJoinProject = async (
+  params: GetJoinProjectRequest
+): Promise<GetJoinProjectResponse> => {
+  const { data } = await axiosInstance.get<GetJoinProjectResponse>(
+    `/api/v1/projects/join?inviteCode=${params.inviteCode}`
+  );
+  return data;
+};
+
+// 프로젝트 참여 (POST)
+export const postJoinProject = async (
+  body: PostJoinProjectRequest
+): Promise<PostJoinProjectResponse> => {
+  const { data } = await axiosInstance.post<PostJoinProjectResponse>('/api/v1/projects/join', body);
+  return data;
+};

--- a/src/types/api/project.ts
+++ b/src/types/api/project.ts
@@ -27,26 +27,11 @@ export interface GetJoinProjectResponse {
     data: any;
   };
   result: {
-    project: {
+    project?: {
       id: string;
       name: string;
+      leader: string;
     };
-    users: Array<{
-      id: number;
-      name: string;
-      email: string;
-      school: string;
-      imageUrl: any;
-      tasks: Array<{
-        taskName: string;
-      }>;
-      permission: string;
-      role: string;
-    }>;
-    posts: Array<{
-      author: string;
-      content: string;
-    }>;
   };
 }
 
@@ -57,9 +42,7 @@ export interface PostJoinProjectRequest {
 export interface PostJoinProjectResponse {
   isSuccess: boolean;
   error: string | null;
-  result: {
-    message: string;
-    projectId: string;
-    projectName: string;
+  result?: {
+    message?: string;
   };
 }

--- a/src/types/api/project.ts
+++ b/src/types/api/project.ts
@@ -11,3 +11,30 @@ export interface CreateProjectReponse {
     inviteCode: string;
   };
 }
+
+export interface JoinProjectResponse {
+  isSuccess: boolean;
+  error: any;
+  result: {
+    project: {
+      id: string;
+      name: string;
+    };
+    users: Array<{
+      id: number;
+      name: string;
+      email: string;
+      school: string;
+      imageUrl: any;
+      tasks: Array<{
+        taskName: string;
+      }>;
+      permission: string;
+      role: string;
+    }>;
+    posts: Array<{
+      author: string;
+      content: string;
+    }>;
+  };
+}

--- a/src/types/api/project.ts
+++ b/src/types/api/project.ts
@@ -6,15 +6,26 @@ export interface CreateProjectReponse {
   isSuccess: boolean;
   error: string;
   result: {
-    id: string;
-    name: string;
-    inviteCode: string;
+    result: {
+      id: string;
+      name: string;
+      inviteCode: string;
+      expiresAt: string;
+    };
   };
 }
 
-export interface JoinProjectResponse {
+export interface GetJoinProjectRequest {
+  inviteCode: string;
+}
+
+export interface GetJoinProjectResponse {
   isSuccess: boolean;
-  error: any;
+  error: {
+    errorCode: string;
+    reason: string;
+    data: any;
+  };
   result: {
     project: {
       id: string;
@@ -36,5 +47,19 @@ export interface JoinProjectResponse {
       author: string;
       content: string;
     }>;
+  };
+}
+
+export interface PostJoinProjectRequest {
+  inviteCode: string;
+}
+
+export interface PostJoinProjectResponse {
+  isSuccess: boolean;
+  error: string | null;
+  result: {
+    message: string;
+    projectId: string;
+    projectName: string;
   };
 }

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -26,3 +26,19 @@ export const formatDateRange = (startDate: string, endDate: string): string => {
     return `${startDate}~${endDate}`;
   }
 };
+
+export const formatToKoreanDate = (dateString: string): string => {
+  if (!dateString) return '';
+
+  try {
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1; // getMonth()는 0부터 시작합니다.
+    const day = date.getDate();
+
+    return `${year}년 ${month}월 ${day}일까지`;
+  } catch (error) {
+    console.error('Invalid date string:', dateString, error);
+    return '날짜 정보 없음';
+  }
+};


### PR DESCRIPTION
## 연관 이슈
- Closes #79 

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
프로젝트 참여 페이지 UI 구현과 API 연동 동시 작업했습니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
중간에 생성 페이지 변경 사항이 생겨서 체리피킹해서 브랜치를 새로 땄습니다. 따라서 해당 페이지와 책임 분리가 안되어있어 의존성 때문에 지금 PR만 머지 시에는 오류가 날 수 있습니다. 이후 프로젝트 생성 페이지 리팩토링 PR 바로 올리도록 하겠습니다.

## 첨부 자료
-
