### PR TITLE
[Feat/106] 프로젝트 생성 페이지 throttle 적용

### DIFF
--- a/src/app/(main)/new/page.tsx
+++ b/src/app/(main)/new/page.tsx
@@ -5,6 +5,7 @@ import { useCreateProject } from '@/hooks/mutations/useCreateProject';
 import { formatToKoreanDate } from '@/utils/formatDate';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useThrottle } from '@/hooks/useThrottle';
 
 export default function New() {
   const router = useRouter();
@@ -13,6 +14,9 @@ export default function New() {
   const [projectName, setProjectName] = useState('');
   const [inviteCode, setInviteCode] = useState('');
   const [expiresAt, setExpiresAt] = useState('');
+
+  // 1초 throttle 적용
+  const throttledCreateProject = useThrottle(1000);
 
   const createProjectMutation = useCreateProject(
     (response) => {
@@ -38,7 +42,10 @@ export default function New() {
       return;
     }
 
-    createProjectMutation.mutate({ name: projectName });
+    // throttle 적용하여 중복 요청 방지
+    throttledCreateProject(() => {
+      createProjectMutation.mutate({ name: projectName });
+    });
   };
 
   const handleRedirect = () => {

--- a/src/hooks/useThrottle.ts
+++ b/src/hooks/useThrottle.ts
@@ -1,0 +1,26 @@
+import { useRef, useCallback } from 'react';
+
+// 1초 이내에 동일한 요청을 방지하는 훅
+export const useThrottle = (delay: number = 1000) => {
+  const isThrottled = useRef(false);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const throttledFunction = useCallback(
+    (fn: () => void) => {
+      if (isThrottled.current) {
+        console.log('요청이 너무 빠릅니다. 잠시 후 다시 시도해주세요.');
+        return;
+      }
+
+      isThrottled.current = true;
+      fn();
+
+      timeoutRef.current = setTimeout(() => {
+        isThrottled.current = false;
+      }, delay);
+    },
+    [delay]
+  );
+
+  return throttledFunction;
+};


### PR DESCRIPTION
## 연관 이슈
- Closes #106

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
프로젝트 생성 버튼을 과도하게 연타해 API가 중복으로 요청되는 상황을 피하기 위해 throttle 훅을 구현 후 적용하였습니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-
