### PR TITLE
[Feat/108] 업무 대시보드 페이지 API 연결

### DIFF
--- a/src/app/(main)/projects/[projectId]/dashboard/page.tsx
+++ b/src/app/(main)/projects/[projectId]/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { Searchbar } from '@/components/Searchbar';
 import ToggleButton from '@/components/ToggleButton';
 import StepsBoard from '@/features/boards/StepsBoard';
 import StatusBoard from '@/features/boards/StatusBoard';
-import { mockProjects } from '@/constants/mockData';
+import { useGetDashboard } from '@/hooks/queries/useGetDashboard';
 
 export default function DashboardPage() {
   // 상태 관리: STEP 별로 보기 / 진행 상태별로 보기
@@ -14,9 +14,64 @@ export default function DashboardPage() {
   // 프로젝트 ID 파라미터 가져오기
   const { projectId } = useParams() as { projectId: string };
 
-  // TODO: 목데이터가 아닌 실제 데이터로 대체
-  const project = mockProjects.find((p) => p.id === projectId);
-  const steps = project?.steps ?? [];
+  // 대시보드 데이터 조회
+  const {
+    data: dashboardData,
+    isLoading,
+    error,
+    refetch,
+  } = useGetDashboard({
+    projectId: parseInt(projectId),
+    view: isStepView ? 'step' : 'status',
+  });
+
+  // 뷰 변경 시 데이터 다시 불러오기
+  const handleViewToggle = (isLeftSelected: boolean) => {
+    setIsStepView(isLeftSelected);
+    // 토글 후 잠시 대기 후 데이터 다시 불러오기
+    setTimeout(() => {
+      refetch();
+    }, 100);
+  };
+
+  // 로딩 상태 처리
+  if (isLoading) {
+    return (
+      <div className="min-h-screen w-full bg-white flex items-center justify-center">
+        <div className="text-lg">로딩 중...</div>
+      </div>
+    );
+  }
+
+  // 에러 상태 처리
+  if (error) {
+    return (
+      <div className="min-h-screen w-full bg-white flex items-center justify-center">
+        <div className="text-lg text-red-500">데이터를 불러오는 중 오류가 발생했습니다.</div>
+      </div>
+    );
+  }
+
+  // API 데이터를 기존 컴포넌트가 기대하는 형태로 변환
+  const steps =
+    dashboardData?.steps?.map((apiStep) => ({
+      id: apiStep.stepId,
+      name: apiStep.stepName,
+      items:
+        apiStep.tasks?.map((task) => ({
+          id: task.taskId,
+          title: task.taskName,
+          status: (task.status === 'ONGOING'
+            ? '진행 중'
+            : task.status === 'COMPLETED'
+              ? '완료'
+              : task.status === 'PENDING'
+                ? '시작 전'
+                : '시작 전') as '시작 전' | '진행 중' | '완료',
+          deadline: new Date(task.deadline).toISOString().split('T')[0],
+          assignee: task.managers?.map((manager) => manager.userName) ?? [],
+        })) ?? [],
+    })) ?? [];
 
   return (
     <div className="min-h-screen w-full bg-white flex flex-col">
@@ -35,7 +90,7 @@ export default function DashboardPage() {
       <ToggleButton
         leftLabel="STEP 별로 보기"
         rightLabel="진행 상태별로 보기"
-        onToggle={(isLeftSelected) => setIsStepView(isLeftSelected)}
+        onToggle={handleViewToggle}
       />
 
       <main className="flex-1 overflow-x-auto">

--- a/src/app/(main)/projects/[projectId]/dashboard/page.tsx
+++ b/src/app/(main)/projects/[projectId]/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { useGetDashboard } from '@/hooks/queries/useGetDashboard';
 export default function DashboardPage() {
   // 상태 관리: STEP 별로 보기 / 진행 상태별로 보기
   const [isStepView, setIsStepView] = useState(true);
+
   // 프로젝트 ID 파라미터 가져오기
   const { projectId } = useParams() as { projectId: string };
 
@@ -52,33 +53,19 @@ export default function DashboardPage() {
     );
   }
 
-  // API 데이터를 기존 컴포넌트가 기대하는 형태로 변환
-  const steps =
-    dashboardData?.steps?.map((apiStep) => ({
-      id: apiStep.stepId,
-      name: apiStep.stepName,
-      items:
-        apiStep.tasks?.map((task) => ({
-          id: task.taskId,
-          title: task.taskName,
-          status: (task.status === 'ONGOING'
-            ? '진행 중'
-            : task.status === 'COMPLETED'
-              ? '완료'
-              : task.status === 'PENDING'
-                ? '시작 전'
-                : '시작 전') as '시작 전' | '진행 중' | '완료',
-          deadline: new Date(task.deadline).toISOString().split('T')[0],
-          assignee: task.managers?.map((manager) => manager.userName) ?? [],
-        })) ?? [],
-    })) ?? [];
-
   return (
     <div className="min-h-screen w-full bg-white flex flex-col">
       <header className="flex items-center justify-between pb-[1rem] px-[0.5rem] border-b-[0.125rem] border-[#E7E7E7]">
-        <h1 className="lg:text-[1.5rem] text-[1.375rem] lg:font-bold font-semibold">
-          업무 대시보드
-        </h1>
+        <div>
+          <h1 className="lg:text-[1.5rem] text-[1.375rem] lg:font-bold font-semibold">
+            업무 대시보드
+          </h1>
+          {dashboardData && (
+            <p className="text-sm text-gray-600 mt-1">
+              {dashboardData.projectName} • 총 {dashboardData.totalCount}개 업무
+            </p>
+          )}
+        </div>
         <div className="flex-1 flex justify-end"></div>
         <Searchbar
           placeholder="검색어를 입력하세요."
@@ -90,6 +77,7 @@ export default function DashboardPage() {
       <ToggleButton
         leftLabel="STEP 별로 보기"
         rightLabel="진행 상태별로 보기"
+        isLeftSelected={isStepView}
         onToggle={handleViewToggle}
       />
 
@@ -101,9 +89,9 @@ export default function DashboardPage() {
           }}
         >
           {isStepView ? (
-            <StepsBoard steps={steps} projectId={projectId} />
+            <StepsBoard steps={dashboardData?.steps || []} projectId={projectId} />
           ) : (
-            <StatusBoard steps={steps} projectId={projectId} />
+            <StatusBoard steps={dashboardData?.steps || []} projectId={projectId} />
           )}
         </div>
       </main>

--- a/src/app/(main)/projects/[projectId]/dashboard/page.tsx
+++ b/src/app/(main)/projects/[projectId]/dashboard/page.tsx
@@ -60,11 +60,6 @@ export default function DashboardPage() {
           <h1 className="lg:text-[1.5rem] text-[1.375rem] lg:font-bold font-semibold">
             업무 대시보드
           </h1>
-          {dashboardData && (
-            <p className="text-sm text-gray-600 mt-1">
-              {dashboardData.projectName} • 총 {dashboardData.totalCount}개 업무
-            </p>
-          )}
         </div>
         <div className="flex-1 flex justify-end"></div>
         <Searchbar

--- a/src/app/(main)/projects/[projectId]/dashboard/page.tsx
+++ b/src/app/(main)/projects/[projectId]/dashboard/page.tsx
@@ -84,9 +84,17 @@ export default function DashboardPage() {
           }}
         >
           {isStepView ? (
-            <StepsBoard steps={dashboardData?.steps || []} projectId={projectId} />
+            <StepsBoard
+              steps={dashboardData && 'steps' in dashboardData ? dashboardData.steps : []}
+              projectId={projectId}
+            />
           ) : (
-            <StatusBoard steps={dashboardData?.steps || []} projectId={projectId} />
+            <StatusBoard
+              statusGroups={
+                dashboardData && 'statusGroups' in dashboardData ? dashboardData.statusGroups : []
+              }
+              projectId={projectId}
+            />
           )}
         </div>
       </main>

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -1,12 +1,9 @@
 'use client';
 
 import { formatDate } from '@/utils/formatDate';
-import { TaskItemProps } from '@/constants/mockData';
+import { useTaskItems } from '@/features/boards/hooks/useTaskItems';
+import { TaskItemComponentProps, TASK_STATUS_STYLES } from '@/types/api/taskItem';
 import Link from 'next/link';
-
-interface TaskItemComponentProps extends TaskItemProps {
-  projectId: string;
-}
 
 export default function TaskItem({
   projectId,
@@ -16,51 +13,16 @@ export default function TaskItem({
   deadline,
   assignee,
 }: TaskItemComponentProps) {
-  // 마감기한이 경과했는지 확인 (완료 상태가 아닌 경우에만)
-  const isDeadlineOverdue = () => {
-    if (!deadline || status === '완료') return false;
-    const deadlineDate = new Date(deadline);
-    const today = new Date();
-    return deadlineDate < today;
-  };
+  const { displayAssignees, /* cardHeight, */ deadlineTextColor } = useTaskItems({
+    task: { id: taskId, title, status, deadline, assignee },
+  });
 
-  // 담당자 표시 로직 (최대 3명 + ...)
-  const displayAssignees = () => {
-    if (!assignee || assignee.length === 0) return null;
-
-    const maxDisplay = 3;
-    const displayList = assignee.slice(0, maxDisplay);
-    const hasMore = assignee.length > maxDisplay;
-
-    return (
-      <div className="mt-auto flex flex-wrap gap-2">
-        {displayList.map((name, index) => (
-          <div
-            key={index}
-            className="inline-flex items-center gap-[4px] rounded-[30px] p-[3px] pr-[9px]"
-            style={{ boxShadow: '1px 1px 4px 0 rgba(0,0,0,0.25)' }}
-          >
-            <img src="/icons/assignee.svg" alt="참석자 아이콘" className="w-[16px] h-[16px]" />
-            <span className="text-[12px]">{name}</span>
-          </div>
-        ))}
-        {hasMore && (
-          <div className="inline-flex items-center rounded-[30px] p-[3px] pr-[9px] text-[12px] text-[#898989]">
-            ...
-          </div>
-        )}
-      </div>
-    );
-  };
-
-  // 카드 높이 조정 (담당자가 없으면 더 작게)
-  const cardHeight = assignee && assignee.length > 0 ? 'h-[122px]' : 'h-[90px]';
+  // 상태별 스타일 가져오기 (타입 안전성 보장)
+  const statusStyle = TASK_STATUS_STYLES[status] || TASK_STATUS_STYLES['시작 전'];
 
   return (
-    <Link
-      href={`/projects/${projectId}/tasks/${taskId}`}
-      className={`block w-[325px] ${cardHeight}`}
-    >
+    <Link href={`/projects/${projectId}/tasks/${taskId}`} className={`block w-[325px] h-[122px]`}>
+      {/* 위 height만 &{cardHeight}으로 바꾸면 담당자 없을 시에 카드 높이 조정 122px -> 90px */}
       <div className="bg-white w-full h-full rounded-[8px] border border-[#BBBBBB] p-4 flex items-start gap-3">
         <label className="inline-flex items-center flex-shrink-0 mt-1">
           <input
@@ -88,29 +50,43 @@ export default function TaskItem({
           <div className="flex items-center justify-between gap-[2px] text-[14px]">
             {/* 마감기한 (선택) */}
             {deadline ? (
-              <span className={`${isDeadlineOverdue() ? 'text-red-500' : 'text-[#898989]'}`}>
-                {formatDate(deadline)}까지
-              </span>
+              <span className={deadlineTextColor}>{formatDate(deadline)}까지</span>
             ) : (
               <span className="text-[#898989]">마감일 없음</span>
             )}
 
             {/* 진행상태 배지 */}
             <div
-              className={`flex items-center justify-center px-2 py-0.5 w-[63px] h-[22px] rounded-full font-semibold ${
-                status === '진행 중'
-                  ? 'bg-[#B6F5DF] text-[#505050]'
-                  : status === '완료'
-                    ? 'bg-[#D1D5DB] text-[#505050]'
-                    : 'bg-[#E7E7E7] text-[#505050]'
-              }`}
+              className={`flex items-center justify-center px-2 py-0.5 w-[63px] h-[22px] rounded-full font-semibold ${statusStyle.bg} ${statusStyle.text}`}
             >
               {status}
             </div>
           </div>
 
           {/* 담당자 (선택) */}
-          {displayAssignees()}
+          {displayAssignees && (
+            <div className="mt-auto flex flex-wrap gap-2">
+              {displayAssignees.displayList.map((name, index) => (
+                <div
+                  key={index}
+                  className="inline-flex items-center gap-[4px] rounded-[30px] p-[3px] pr-[9px]"
+                  style={{ boxShadow: '1px 1px 4px 0 rgba(0,0,0,0.25)' }}
+                >
+                  <img
+                    src="/icons/assignee.svg"
+                    alt="참석자 아이콘"
+                    className="w-[16px] h-[16px]"
+                  />
+                  <span className="text-[12px]">{name}</span>
+                </div>
+              ))}
+              {displayAssignees.hasMore && (
+                <div className="inline-flex items-center rounded-[30px] p-[3px] pr-[9px] text-[12px] text-[#898989]">
+                  ...
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </Link>

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -13,7 +13,7 @@ export default function TaskItem({
   deadline,
   assignee,
 }: TaskItemComponentProps) {
-  const { displayAssignees, cardHeight, deadlineTextColor } = useTaskItems({
+  const { displayAssignees, /* cardHeight, */ deadlineTextColor } = useTaskItems({
     task: { id: taskId, title, status, deadline, assignee },
   });
 
@@ -23,7 +23,8 @@ export default function TaskItem({
   return (
     <Link
       href={`/projects/${projectId}/tasks/${taskId}`}
-      className={`block w-[325px] ${cardHeight}`}
+      className={`block w-[325px] h-[122px]`}
+      /* 위 height만 &{cardHeight}으로 바꾸면 담당자 없을 시에 카드 높이 조정 122px -> 90px */
     >
       <div className="bg-white w-full h-full rounded-[8px] border border-[#BBBBBB] p-4 flex items-start gap-3">
         <label className="inline-flex items-center flex-shrink-0 mt-1">

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -16,8 +16,51 @@ export default function TaskItem({
   deadline,
   assignee,
 }: TaskItemComponentProps) {
+  // 마감기한이 경과했는지 확인 (완료 상태가 아닌 경우에만)
+  const isDeadlineOverdue = () => {
+    if (!deadline || status === '완료') return false;
+    const deadlineDate = new Date(deadline);
+    const today = new Date();
+    return deadlineDate < today;
+  };
+
+  // 담당자 표시 로직 (최대 3명 + ...)
+  const displayAssignees = () => {
+    if (!assignee || assignee.length === 0) return null;
+
+    const maxDisplay = 3;
+    const displayList = assignee.slice(0, maxDisplay);
+    const hasMore = assignee.length > maxDisplay;
+
+    return (
+      <div className="mt-auto flex flex-wrap gap-2">
+        {displayList.map((name, index) => (
+          <div
+            key={index}
+            className="inline-flex items-center gap-[4px] rounded-[30px] p-[3px] pr-[9px]"
+            style={{ boxShadow: '1px 1px 4px 0 rgba(0,0,0,0.25)' }}
+          >
+            <img src="/icons/assignee.svg" alt="참석자 아이콘" className="w-[16px] h-[16px]" />
+            <span className="text-[12px]">{name}</span>
+          </div>
+        ))}
+        {hasMore && (
+          <div className="inline-flex items-center rounded-[30px] p-[3px] pr-[9px] text-[12px] text-[#898989]">
+            ...
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  // 카드 높이 조정 (담당자가 없으면 더 작게)
+  const cardHeight = assignee && assignee.length > 0 ? 'h-[122px]' : 'h-[90px]';
+
   return (
-    <Link href={`/projects/${projectId}/tasks/${taskId}`} className="block w-[325px] h-[122px]">
+    <Link
+      href={`/projects/${projectId}/tasks/${taskId}`}
+      className={`block w-[325px] ${cardHeight}`}
+    >
       <div className="bg-white w-full h-full rounded-[8px] border border-[#BBBBBB] p-4 flex items-start gap-3">
         <label className="inline-flex items-center flex-shrink-0 mt-1">
           <input
@@ -38,14 +81,21 @@ export default function TaskItem({
         </label>
 
         <div className="flex flex-col flex-1 gap-[10px]">
+          {/* 업무명 (필수) */}
           <div className="font-normal text-[16px] text-black mt-[1px]">{title}</div>
 
-          <div className="flex items-center justify-between gap-[2px] text-[14px] text-[#898989]">
-            {formatDate(deadline) === '마감일 없음' ? (
-              <span>마감일 없음</span>
+          {/* 진행상태 (필수) */}
+          <div className="flex items-center justify-between gap-[2px] text-[14px]">
+            {/* 마감기한 (선택) */}
+            {deadline ? (
+              <span className={`${isDeadlineOverdue() ? 'text-red-500' : 'text-[#898989]'}`}>
+                {formatDate(deadline)}까지
+              </span>
             ) : (
-              <span>{formatDate(deadline)}까지</span>
+              <span className="text-[#898989]">마감일 없음</span>
             )}
+
+            {/* 진행상태 배지 */}
             <div
               className={`flex items-center justify-center px-2 py-0.5 w-[63px] h-[22px] rounded-full font-semibold ${
                 status === '진행 중'
@@ -59,24 +109,8 @@ export default function TaskItem({
             </div>
           </div>
 
-          {assignee && assignee.length > 0 && (
-            <div className="mt-auto flex flex-wrap gap-2">
-              {assignee.map((name, index) => (
-                <div
-                  key={index}
-                  className="inline-flex items-center gap-[4px] rounded-[30px] p-[3px] pr-[9px]"
-                  style={{ boxShadow: '1px 1px 4px 0 rgba(0,0,0,0.25)' }}
-                >
-                  <img
-                    src="/icons/assignee.svg"
-                    alt="참석자 아이콘"
-                    className="w-[16px] h-[16px]"
-                  />
-                  <span className="text-[12px]">{name}</span>
-                </div>
-              ))}
-            </div>
-          )}
+          {/* 담당자 (선택) */}
+          {displayAssignees()}
         </div>
       </div>
     </Link>

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -2,7 +2,7 @@
 
 import { formatDate } from '@/utils/formatDate';
 import { useTaskItems } from '@/features/boards/hooks/useTaskItems';
-import { TaskItemComponentProps, TASK_STATUS_STYLES } from '@/types/api/taskItem';
+import { TaskItemComponentProps, TASK_STATUS_STYLES } from '@/types/api/tasks';
 import Link from 'next/link';
 
 export default function TaskItem({
@@ -13,7 +13,7 @@ export default function TaskItem({
   deadline,
   assignee,
 }: TaskItemComponentProps) {
-  const { displayAssignees, /* cardHeight, */ deadlineTextColor } = useTaskItems({
+  const { displayAssignees, cardHeight, deadlineTextColor } = useTaskItems({
     task: { id: taskId, title, status, deadline, assignee },
   });
 
@@ -21,8 +21,10 @@ export default function TaskItem({
   const statusStyle = TASK_STATUS_STYLES[status] || TASK_STATUS_STYLES['시작 전'];
 
   return (
-    <Link href={`/projects/${projectId}/tasks/${taskId}`} className={`block w-[325px] h-[122px]`}>
-      {/* 위 height만 &{cardHeight}으로 바꾸면 담당자 없을 시에 카드 높이 조정 122px -> 90px */}
+    <Link
+      href={`/projects/${projectId}/tasks/${taskId}`}
+      className={`block w-[325px] ${cardHeight}`}
+    >
       <div className="bg-white w-full h-full rounded-[8px] border border-[#BBBBBB] p-4 flex items-start gap-3">
         <label className="inline-flex items-center flex-shrink-0 mt-1">
           <input

--- a/src/components/ToggleButton.tsx
+++ b/src/components/ToggleButton.tsx
@@ -1,18 +1,19 @@
 'use client';
 
-import { useState } from 'react';
-
 interface ToggleButtonProps {
   leftLabel: string;
   rightLabel: string;
+  isLeftSelected: boolean;
   onToggle?: (isLeftSelected: boolean) => void;
 }
 
-export default function ToggleButton({ leftLabel, rightLabel, onToggle }: ToggleButtonProps) {
-  const [isLeftSelected, setIsLeftSelected] = useState(true);
-
+export default function ToggleButton({
+  leftLabel,
+  rightLabel,
+  isLeftSelected,
+  onToggle,
+}: ToggleButtonProps) {
   const handleToggle = (isLeft: boolean) => {
-    setIsLeftSelected(isLeft);
     onToggle?.(isLeft);
   };
 

--- a/src/constants/mockData.ts
+++ b/src/constants/mockData.ts
@@ -23,16 +23,17 @@ export const mockProjects: Project[] = [
         items: [
           {
             id: 1,
-            title: '기획서 초안 작성',
+            title: '놀라지 마세요',
             status: '진행 중',
-            deadline: '2024-05-04',
-            assignee: ['홍길동', '이순신'],
+            deadline: '2025-09-04',
+            assignee: ['김태화', '두현우'],
           },
           {
             id: 2,
-            title: '요구사항 정리',
+            title: 'mockData 입니다',
             status: '시작 전',
-            deadline: '2024-05-07',
+            deadline: '2025-09-07',
+            assignee: ['김태화'],
           },
         ],
       },
@@ -42,10 +43,10 @@ export const mockProjects: Project[] = [
         items: [
           {
             id: 3,
-            title: '와이어프레임 제작',
+            title: '^________^',
             status: '완료',
-            deadline: '2024-05-10',
-            assignee: ['김디자이너'],
+            deadline: '2025-10-10',
+            assignee: ['김태화'],
           },
         ],
       },
@@ -54,6 +55,20 @@ export const mockProjects: Project[] = [
   {
     id: '456',
     name: '프로젝트 B',
-    steps: [],
+    steps: [
+      {
+        id: 1,
+        name: '기획',
+        items: [
+          {
+            id: 1,
+            title: 'Teamie 화이팅!',
+            status: '진행 중',
+            deadline: '2025-09-04',
+            assignee: ['김태화', '이예린'],
+          },
+        ],
+      },
+    ],
   },
 ];

--- a/src/constants/mockData.ts
+++ b/src/constants/mockData.ts
@@ -1,4 +1,4 @@
-import { TaskItemProps } from '@/types/api/taskItem';
+import { TaskItemProps } from '@/types/api/tasks';
 
 export interface Step {
   id: number;

--- a/src/constants/mockData.ts
+++ b/src/constants/mockData.ts
@@ -1,10 +1,4 @@
-export interface TaskItemProps {
-  id: number;
-  title: string;
-  status: '시작 전' | '진행 중' | '완료';
-  deadline: string;
-  assignee?: string[];
-}
+import { TaskItemProps } from '@/types/api/taskItem';
 
 export interface Step {
   id: number;

--- a/src/features/boards/MyTaskBoard.tsx
+++ b/src/features/boards/MyTaskBoard.tsx
@@ -4,7 +4,7 @@ import { mockProjects } from '@/constants/mockData';
 import ProjectHeader from './components/ProjectHeader';
 
 // 임시 로그인 사용자
-const currentUser = '홍길동';
+const currentUser = '김태화';
 
 export default function MyTaskBoard() {
   // 프로젝트별로, 모든 step의 items 중 담당자가 currentUser인 태스크만 한 배열로 합침

--- a/src/features/boards/StatusBoard.tsx
+++ b/src/features/boards/StatusBoard.tsx
@@ -1,14 +1,39 @@
 import TaskItem from '@/components/TaskItem';
 import { STATUS_ORDER } from '@/constants/constants';
-import { BoardProps } from '@/types/board';
+import { StatusBoardProps } from '@/types/board';
+import { Task } from '@/types/api/tasks';
 
-export default function StatusBoard({ steps, projectId }: BoardProps) {
-  const allTasks = steps.flatMap((step) => step.items);
+export default function StatusBoard({ statusGroups, projectId }: StatusBoardProps) {
+  // API 상태를 표시 상태로 변환
+  const getDisplayStatus = (apiStatus: string) => {
+    switch (apiStatus) {
+      case 'ONGOING':
+        return '진행 중';
+      case 'COMPLETED':
+        return '완료';
+      case 'NOTSTART':
+        return '시작 전';
+      case 'PENDING':
+        return '시작 전';
+      default:
+        return '시작 전';
+    }
+  };
+
+  // statusGroups 구조에 맞게 모든 업무를 평탄화하고 status 정보 추가
+  const allTasksWithStatus: (Task & { displayStatus: string })[] = statusGroups.flatMap(
+    (statusGroup) =>
+      (statusGroup.tasks || []).map((task: Task) => ({
+        ...task,
+        displayStatus: getDisplayStatus(statusGroup.status),
+      }))
+  );
 
   return (
     <div className="grid [grid-template-columns:repeat(2,20.313rem)] lg:[grid-template-columns:repeat(4,20.313rem)] gap-x-[2.25rem] gap-y-[5rem] mt-[3.75rem]">
       {STATUS_ORDER.map(({ status, color }) => {
-        const tasksByStatus = allTasks.filter((task) => task.status === status);
+        // 해당 상태의 업무들 필터링
+        const tasksByStatus = allTasksWithStatus.filter((task) => task.displayStatus === status);
 
         return (
           <div key={status} className="flex flex-col">
@@ -19,17 +44,16 @@ export default function StatusBoard({ steps, projectId }: BoardProps) {
               {status}
             </div>
 
-            <div className="mt-4">
+            <div className="mt-4 space-y-3">
               {tasksByStatus.map((task) => (
-                // Task 목록 렌더링
                 <TaskItem
-                  key={task.id}
+                  key={task.taskId}
                   projectId={projectId}
-                  id={task.id}
-                  title={task.title}
-                  status={task.status}
+                  id={task.taskId}
+                  title={task.taskName}
+                  status={task.displayStatus}
                   deadline={task.deadline}
-                  assignee={task.assignee}
+                  assignee={task.managers.map((manager) => manager.userName)}
                 />
               ))}
             </div>

--- a/src/features/boards/StepsBoard.tsx
+++ b/src/features/boards/StepsBoard.tsx
@@ -6,10 +6,12 @@ import { BoardProps } from '@/types/board';
 import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
 import React, { useState } from 'react';
 import { useCreateStep } from '@/hooks/mutations/useCreateStep';
+import { useDeleteStep } from '@/hooks/mutations/useDeleteStep';
 
 export default function StepsBoard({ steps, projectId }: BoardProps) {
-  const { openStepIds, toggleStep } = useSteps();
+  const { openStepIds, toggleStep, openStep } = useSteps();
   const createStepMutation = useCreateStep();
+  const deleteStepMutation = useDeleteStep();
   const [isAddingStep, setIsAddingStep] = useState(false);
   const [newStepName, setNewStepName] = useState('');
 
@@ -35,7 +37,7 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
     const finalStepName = stepName.trim() || '빈 STEP';
 
     try {
-      await createStepMutation.mutateAsync({
+      const response = await createStepMutation.mutateAsync({
         projectId: parseInt(projectId),
         body: { name: finalStepName },
       });
@@ -43,6 +45,11 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
       // 성공 시 입력 필드 초기화
       setNewStepName('');
       setIsAddingStep(false);
+
+      // 새로 생성된 스텝을 자동으로 열기
+      if (response.result?.stepId) {
+        openStep(response.result.stepId);
+      }
     } catch (error) {
       console.error('STEP 생성 실패:', error);
       alert('STEP 생성에 실패했습니다.');
@@ -64,9 +71,19 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
     handleAddStep(newStepName);
   };
 
-  // TODO: 실제로는 step 삭제 로직을 구현해야 함
-  const handleDeleteStep = (stepId: number) => {
-    alert(`STEP ${stepId} 삭제!`);
+  // STEP 삭제 처리
+  const handleDeleteStep = async (stepId: number) => {
+    // if (!confirm('정말로 이 STEP을 삭제하시겠습니까?')) {
+    //   return;
+    // }
+
+    try {
+      await deleteStepMutation.mutateAsync(stepId);
+      // 성공 시 쿼리 무효화로 자동으로 데이터가 업데이트됩니다
+    } catch (error) {
+      console.error('STEP 삭제 실패:', error);
+      alert('STEP 삭제에 실패했습니다.');
+    }
   };
 
   // 드래그가 끝났을 때 호출되는 함수

--- a/src/features/boards/StepsBoard.tsx
+++ b/src/features/boards/StepsBoard.tsx
@@ -8,7 +8,7 @@ import React, { useState } from 'react';
 import { useCreateStep } from '@/hooks/mutations/useCreateStep';
 import { useDeleteStep } from '@/hooks/mutations/useDeleteStep';
 import { useUpdateStep } from '@/hooks/mutations/useUpdateStep';
-import { TASK_STATUS_DISPLAY } from '@/types/api/taskItem';
+import { TASK_STATUS_DISPLAY } from '@/types/api/tasks';
 
 export default function StepsBoard({ steps, projectId }: BoardProps) {
   const { openStepIds, toggleStep, openStep } = useSteps();

--- a/src/features/boards/StepsBoard.tsx
+++ b/src/features/boards/StepsBoard.tsx
@@ -8,6 +8,7 @@ import React, { useState } from 'react';
 import { useCreateStep } from '@/hooks/mutations/useCreateStep';
 import { useDeleteStep } from '@/hooks/mutations/useDeleteStep';
 import { useUpdateStep } from '@/hooks/mutations/useUpdateStep';
+import { TASK_STATUS_DISPLAY } from '@/types/api/taskItem';
 
 export default function StepsBoard({ steps, projectId }: BoardProps) {
   const { openStepIds, toggleStep, openStep } = useSteps();
@@ -20,15 +21,15 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
   // STEP 추가 제한 (최대 8개)
   const canAddStep = steps.length < 8;
 
-  // 상태 매핑 함수
+  // 상태 매핑 함수 (API 상태를 표시 텍스트로 변환)
   const mapTaskStatus = (status: string) => {
     switch (status) {
       case 'ONGOING':
-        return '진행 중';
+        return TASK_STATUS_DISPLAY.ONGOING;
       case 'COMPLETED':
-        return '완료';
+        return TASK_STATUS_DISPLAY.COMPLETE;
       default:
-        return '시작 전';
+        return TASK_STATUS_DISPLAY.BEFORE;
     }
   };
 
@@ -41,7 +42,7 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
     try {
       const response = await createStepMutation.mutateAsync({
         projectId: parseInt(projectId),
-        body: { name: finalStepName },
+        name: finalStepName,
       });
 
       // 성공 시 입력 필드 초기화

--- a/src/features/boards/StepsBoard.tsx
+++ b/src/features/boards/StepsBoard.tsx
@@ -7,11 +7,13 @@ import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea
 import React, { useState } from 'react';
 import { useCreateStep } from '@/hooks/mutations/useCreateStep';
 import { useDeleteStep } from '@/hooks/mutations/useDeleteStep';
+import { useUpdateStep } from '@/hooks/mutations/useUpdateStep';
 
 export default function StepsBoard({ steps, projectId }: BoardProps) {
   const { openStepIds, toggleStep, openStep } = useSteps();
   const createStepMutation = useCreateStep();
   const deleteStepMutation = useDeleteStep();
+  const updateStepMutation = useUpdateStep();
   const [isAddingStep, setIsAddingStep] = useState(false);
   const [newStepName, setNewStepName] = useState('');
 
@@ -86,6 +88,17 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
     }
   };
 
+  // STEP 이름 수정 처리
+  const handleUpdateStepName = async (stepId: number, newName: string) => {
+    try {
+      await updateStepMutation.mutateAsync({ stepId, name: newName });
+      // 성공 시 쿼리 무효화로 자동으로 데이터가 업데이트됩니다
+    } catch (error) {
+      console.error('STEP 이름 수정 실패:', error);
+      throw error; // StepHeader에서 처리하도록 에러를 다시 던짐
+    }
+  };
+
   // 드래그가 끝났을 때 호출되는 함수
   const onDragEnd = (result: DropResult) => {
     const { source, destination } = result;
@@ -118,10 +131,12 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
           <div key={step.stepId} className="flex flex-col">
             <StepHeader
               stepName={step.stepName}
+              stepId={step.stepId}
               isOpen={openStepIds.includes(step.stepId)}
               onToggle={() => toggleStep(step.stepId)}
               showDelete={step.tasks.length === 0}
               onDelete={() => handleDeleteStep(step.stepId)}
+              onUpdateName={handleUpdateStepName}
             />
             {openStepIds.includes(step.stepId) && (
               <Droppable droppableId={step.stepId.toString()}>

--- a/src/features/boards/StepsBoard.tsx
+++ b/src/features/boards/StepsBoard.tsx
@@ -1,16 +1,17 @@
-import StepHeader from './components/StepHeader';
-import AddTaskButton from './components/AddTaskButton';
-import TaskItem from '@/components/TaskItem';
-import { useSteps } from './hooks/useSteps';
-import { BoardProps } from '@/types/board';
-import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useCreateStep } from '@/hooks/mutations/useCreateStep';
 import { useDeleteStep } from '@/hooks/mutations/useDeleteStep';
 import { useUpdateStep } from '@/hooks/mutations/useUpdateStep';
+import { useCreateTask } from '@/hooks/mutations/useCreateTask';
 import { TASK_STATUS_DISPLAY } from '@/types/api/tasks';
+import { StepsBoardProps } from '@/types/board';
+import { useSteps } from './hooks/useSteps';
+import AddTaskButton from './components/AddTaskButton';
+import StepHeader from './components/StepHeader';
+import TaskItem from '@/components/TaskItem';
+import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
 
-export default function StepsBoard({ steps, projectId }: BoardProps) {
+export default function StepsBoard({ steps, projectId }: StepsBoardProps) {
   const { openStepIds, toggleStep, openStep } = useSteps();
   const createStepMutation = useCreateStep();
   const deleteStepMutation = useDeleteStep();

--- a/src/features/boards/StepsBoard.tsx
+++ b/src/features/boards/StepsBoard.tsx
@@ -4,10 +4,65 @@ import TaskItem from '@/components/TaskItem';
 import { useSteps } from './hooks/useSteps';
 import { BoardProps } from '@/types/board';
 import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
-import React from 'react';
+import React, { useState } from 'react';
+import { useCreateStep } from '@/hooks/mutations/useCreateStep';
 
 export default function StepsBoard({ steps, projectId }: BoardProps) {
-  const { steps: localSteps, openStepIds, toggleStep, addStep, moveTask } = useSteps(steps);
+  const { openStepIds, toggleStep } = useSteps();
+  const createStepMutation = useCreateStep();
+  const [isAddingStep, setIsAddingStep] = useState(false);
+  const [newStepName, setNewStepName] = useState('');
+
+  // STEP 추가 제한 (최대 8개)
+  const canAddStep = steps.length < 8;
+
+  // 상태 매핑 함수
+  const mapTaskStatus = (status: string) => {
+    switch (status) {
+      case 'ONGOING':
+        return '진행 중';
+      case 'COMPLETED':
+        return '완료';
+      default:
+        return '시작 전';
+    }
+  };
+
+  // STEP 추가 처리
+  const handleAddStep = async (stepName: string = '') => {
+    if (!canAddStep) return;
+
+    const finalStepName = stepName.trim() || '빈 STEP';
+
+    try {
+      await createStepMutation.mutateAsync({
+        projectId: parseInt(projectId),
+        body: { name: finalStepName },
+      });
+
+      // 성공 시 입력 필드 초기화
+      setNewStepName('');
+      setIsAddingStep(false);
+    } catch (error) {
+      console.error('STEP 생성 실패:', error);
+      alert('STEP 생성에 실패했습니다.');
+    }
+  };
+
+  // STEP 추가 모드 토글
+  const toggleAddStepMode = () => {
+    if (canAddStep) {
+      setIsAddingStep(!isAddingStep);
+      if (!isAddingStep) {
+        setNewStepName('');
+      }
+    }
+  };
+
+  // 포커스 아웃 시 자동 저장
+  const handleBlur = () => {
+    handleAddStep(newStepName);
+  };
 
   // TODO: 실제로는 step 삭제 로직을 구현해야 함
   const handleDeleteStep = (stepId: number) => {
@@ -15,7 +70,6 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
   };
 
   // 드래그가 끝났을 때 호출되는 함수
-  // source: 드래그 시작한 위치, destination: 드롭한 위치
   const onDragEnd = (result: DropResult) => {
     const { source, destination } = result;
 
@@ -31,50 +85,42 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
       return;
     }
 
-    // Task를 한 Step에서 다른 Step으로 이동
-    moveTask(sourceStepId, destStepId, source.index, destination.index);
+    // TODO: Task 이동 API 호출 구현
+    console.log('Task 이동:', {
+      sourceStepId,
+      destStepId,
+      sourceIndex: source.index,
+      destIndex: destination.index,
+    });
   };
 
   return (
-    // 전체 드래그앤드롭 컨텍스트 - 모든 드래그앤드롭 이벤트를 관리
     <DragDropContext onDragEnd={onDragEnd}>
       <div className="grid [grid-template-columns:repeat(2,20.313rem)] lg:[grid-template-columns:repeat(4,20.313rem)] gap-x-[2.25rem] gap-y-[5rem] mt-[3.75rem]">
-        {localSteps.map((step) => (
-          <div key={step.id} className="flex flex-col">
+        {steps.map((step) => (
+          <div key={step.stepId} className="flex flex-col">
             <StepHeader
-              stepName={step.name}
-              isOpen={openStepIds.includes(step.id)}
-              onToggle={() => toggleStep(step.id)}
-              showDelete={step.items.length === 0}
-              onDelete={() => handleDeleteStep(step.id)}
+              stepName={step.stepName}
+              isOpen={openStepIds.includes(step.stepId)}
+              onToggle={() => toggleStep(step.stepId)}
+              showDelete={step.tasks.length === 0}
+              onDelete={() => handleDeleteStep(step.stepId)}
             />
-            {openStepIds.includes(step.id) && (
-              // 각 Step은 드롭 가능한 영역 (Droppable)
-              // droppableId: 각 Step을 구분하는 고유 ID
-              <Droppable droppableId={step.id.toString()}>
+            {openStepIds.includes(step.stepId) && (
+              <Droppable droppableId={step.stepId.toString()}>
                 {(provided) => (
-                  // 드롭 가능한 영역의 실제 div
-                  // ref: DnD 라이브러리가 이 div를 드롭 영역으로 인식하게 함
-                  // ...provided.droppableProps: 드롭 관련 이벤트 핸들러들
                   <div
                     ref={provided.innerRef}
                     {...provided.droppableProps}
                     className="flex flex-col mt-6 min-h-[0.625rem]"
                   >
-                    {/* 각 TaskItem은 드래그 가능한 아이템 (Draggable) */}
-                    {step.items.map((task, idx) => (
-                      // draggableId: 각 TaskItem을 구분하는 고유 ID
-                      // index: TaskItem의 순서 (0, 1, 2, ...)
+                    {step.tasks.map((task, idx) => (
                       <Draggable
-                        key={`${step.id}-${task.id}`}
-                        draggableId={task.id.toString()}
+                        key={`${step.stepId}-${task.taskId}`}
+                        draggableId={task.taskId.toString()}
                         index={idx}
                       >
                         {(provided, snapshot) => (
-                          // 드래그 가능한 아이템의 실제 div
-                          // ref: DnD 라이브러리가 이 div를 드래그 아이템으로 인식하게 함
-                          // ...provided.draggableProps: 드래그 관련 스타일 (transform, transition 등)
-                          // ...provided.dragHandleProps: 드래그 핸들러 (어디를 잡고 드래그할지)
                           <div
                             ref={provided.innerRef}
                             {...provided.draggableProps}
@@ -88,11 +134,11 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
                             <div {...provided.dragHandleProps}>
                               <TaskItem
                                 projectId={projectId}
-                                id={task.id}
-                                title={task.title}
-                                status={task.status}
+                                id={task.taskId}
+                                title={task.taskName}
+                                status={mapTaskStatus(task.status)}
                                 deadline={task.deadline}
-                                assignee={task.assignee}
+                                assignee={task.managers.map((manager) => manager.userName)}
                               />
                             </div>
                           </div>
@@ -103,7 +149,7 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
                     {provided.placeholder}
 
                     <div className="mt-2">
-                      <AddTaskButton stepName={step.name} />
+                      <AddTaskButton stepName={step.stepName} />
                     </div>
                   </div>
                 )}
@@ -111,12 +157,37 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
             )}
           </div>
         ))}
-        <button
-          onClick={addStep}
-          className="flex bg-[#F8F8F8] text-[#898989] w-full h-[4.25rem] items-center justify-center rounded-[0.5rem] font-medium text-[1.125rem] cursor-pointer hover:bg-[#F0F0F0] transition-colors duration-200"
-        >
-          + STEP 추가
-        </button>
+
+        {/* STEP 추가 버튼 */}
+        {canAddStep && (
+          <div className="flex flex-col">
+            <div className="flex bg-[#DAF3F3] w-full h-[4.25rem] items-center justify-between rounded-[0.5rem]">
+              {isAddingStep ? (
+                <input
+                  type="text"
+                  value={newStepName}
+                  onChange={(e) => setNewStepName(e.target.value)}
+                  placeholder="STEP 이름을 입력하세요"
+                  className="flex-1 mx-auto text-center font-medium text-[1.125rem] bg-transparent border-none outline-none placeholder-gray-500"
+                  onKeyPress={(e) => {
+                    if (e.key === 'Enter') {
+                      handleAddStep(newStepName);
+                    }
+                  }}
+                  onBlur={handleBlur}
+                  autoFocus
+                />
+              ) : (
+                <button
+                  onClick={toggleAddStepMode}
+                  className="w-full h-full font-medium text-[1.125rem] transition-colors duration-200 text-[#898989] cursor-pointer hover:text-[#666666]"
+                >
+                  + STEP 추가
+                </button>
+              )}
+            </div>
+          </div>
+        )}
       </div>
     </DragDropContext>
   );

--- a/src/features/boards/StepsBoard.tsx
+++ b/src/features/boards/StepsBoard.tsx
@@ -181,7 +181,7 @@ export default function StepsBoard({ steps, projectId }: BoardProps) {
                     {provided.placeholder}
 
                     <div className="mt-2">
-                      <AddTaskButton stepName={step.stepName} />
+                      <AddTaskButton stepId={step.stepId} stepName={step.stepName} />
                     </div>
                   </div>
                 )}

--- a/src/features/boards/components/AddTaskButton.tsx
+++ b/src/features/boards/components/AddTaskButton.tsx
@@ -1,20 +1,31 @@
+import { useCreateTask } from '@/hooks/mutations/useCreateTask';
+
 interface AddTaskButtonProps {
+  stepId: number;
   stepName: string;
   className?: string;
 }
 
-export default function AddTaskButton({ stepName, className = '' }: AddTaskButtonProps) {
-  const handleClick = () => {
-    // TODO: 업무 상세 페이지 라우팅
-    alert(`${stepName}에 새 업무 추가`);
+export default function AddTaskButton({ stepId, stepName, className = '' }: AddTaskButtonProps) {
+  const createTaskMutation = useCreateTask();
+
+  const handleClick = async () => {
+    try {
+      await createTaskMutation.mutateAsync(stepId);
+      // 성공 시 쿼리 무효화로 자동으로 데이터가 업데이트됩니다
+    } catch (error) {
+      console.error('업무 생성 실패:', error);
+      alert('업무 생성에 실패했습니다.');
+    }
   };
 
   return (
     <button
       className={`flex bg-[#FFFFFF] text-[#898989] w-[20.313rem] h-[2.75rem] items-center justify-center rounded-[0.5rem] text-[1rem] cursor-pointer border border-[#BBBBBB] border-[0.094rem] ${className}`}
       onClick={handleClick}
+      disabled={createTaskMutation.isPending}
     >
-      + 업무 추가
+      {createTaskMutation.isPending ? '업무 추가 중...' : '+ 업무 추가'}
     </button>
   );
 }

--- a/src/features/boards/components/StepHeader.tsx
+++ b/src/features/boards/components/StepHeader.tsx
@@ -2,24 +2,65 @@ import { useState } from 'react';
 
 interface StepHeaderProps {
   stepName: string;
+  stepId: number;
   isOpen: boolean;
   onToggle: () => void;
   showDelete?: boolean;
   onDelete?: () => void;
+  onUpdateName?: (stepId: number, newName: string) => Promise<void>;
 }
 
 export default function StepHeader({
   stepName,
+  stepId,
   isOpen,
   onToggle,
   showDelete,
   onDelete,
+  onUpdateName,
 }: StepHeaderProps) {
   const [isHovered, setIsHovered] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState(stepName);
 
   const handleIconClick = (e: React.MouseEvent | React.KeyboardEvent) => {
     e.stopPropagation();
     if (onDelete) onDelete();
+  };
+
+  const handleDoubleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (onUpdateName) {
+      setIsEditing(true);
+      setEditName(stepName);
+    }
+  };
+
+  const handleBlur = async () => {
+    if (!onUpdateName) return;
+
+    const trimmedName = editName.trim();
+    if (trimmedName && trimmedName !== stepName) {
+      try {
+        await onUpdateName(stepId, trimmedName);
+      } catch (error) {
+        console.error('스텝 이름 수정 실패:', error);
+        setEditName(stepName); // 실패 시 원래 이름으로 복원
+      }
+    } else {
+      setEditName(stepName); // 빈 값이거나 변경사항이 없으면 원래 이름으로 복원
+    }
+    setIsEditing(false);
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      e.currentTarget.blur();
+    } else if (e.key === 'Escape') {
+      setEditName(stepName);
+      setIsEditing(false);
+    }
   };
 
   return (
@@ -30,7 +71,24 @@ export default function StepHeader({
     >
       <button onClick={onToggle} className="cursor-pointer w-full">
         <div className="flex bg-[#DAF3F3] w-full h-[4.25rem] items-center justify-between rounded-[0.5rem]">
-          <span className="font-medium text-[1.125rem] mx-auto">{stepName}</span>
+          {isEditing ? (
+            <input
+              type="text"
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              onBlur={handleBlur}
+              onKeyDown={handleKeyPress}
+              className="flex-1 mx-auto text-center font-medium text-[1.125rem] bg-transparent border-none outline-none"
+              autoFocus
+            />
+          ) : (
+            <span
+              className="font-medium text-[1.125rem] mx-auto cursor-pointer"
+              onDoubleClick={handleDoubleClick}
+            >
+              {stepName}
+            </span>
+          )}
           {showDelete && isHovered ? (
             <span
               className="w-[2rem] h-[2rem] mr-[0.25rem] flex items-center justify-center"

--- a/src/features/boards/hooks/useSteps.ts
+++ b/src/features/boards/hooks/useSteps.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 // UI 상태만 관리하는 훅
 export function useSteps() {
@@ -12,8 +12,14 @@ export function useSteps() {
     );
   };
 
+  // 새로 생성된 스텝을 자동으로 열기
+  const openStep = (id: number) => {
+    setOpenStepIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
+  };
+
   return {
     openStepIds,
     toggleStep,
+    openStep,
   };
 }

--- a/src/features/boards/hooks/useSteps.ts
+++ b/src/features/boards/hooks/useSteps.ts
@@ -1,100 +1,19 @@
 'use client';
 
 import { useState } from 'react';
-import { Step } from '@/constants/mockData';
 
-// 드래그앤드롭으로 Task를 이동할 때 상태 업데이트
-export function useSteps(initialSteps: Step[]) {
+// UI 상태만 관리하는 훅
+export function useSteps() {
   const [openStepIds, setOpenStepIds] = useState<number[]>([]);
-
-  // Step들의 데이터를 저장하는 상태
-  // 드래그앤드롭으로 Task가 이동할 때마다 이 상태가 업데이트됨
-  const [steps, setSteps] = useState<Step[]>(initialSteps);
 
   const toggleStep = (id: number) => {
     setOpenStepIds((prev) =>
-      // 이미 열려있으면 제거하고, 닫혀있으면 추가
       prev.includes(id) ? prev.filter((sid) => sid !== id) : [...prev, id]
     );
   };
 
-  // 새로운 Step을 추가하는 함수
-  // "+ STEP 추가" 버튼을 클릭했을 때 호출됨
-  const addStep = () => {
-    // TODO: 이름 유저가 설정할 수 있도록 하기
-    // 새로운 Step의 ID를 생성 (기존 ID 중 가장 큰 값 + 1)
-    const newId = steps.length ? Math.max(...steps.map((s) => s.id)) + 1 : 1;
-
-    // 새로운 Step을 배열 맨 뒤에 추가
-    setSteps([...steps, { id: newId, name: `새 STEP ${newId}`, items: [] }]);
-  };
-
-  // Task STEP 변경 함수
-  // sourceStepId: Task가 있던 Step의 ID
-  // destStepId: Task를 옮길 Step의 ID
-  // sourceIndex: Task가 있던 위치
-  // destIndex: Task를 옮길 위치
-  const moveTask = (
-    sourceStepId: number,
-    destStepId: number,
-    sourceIndex: number,
-    destIndex: number
-  ) => {
-    setSteps((prevSteps) => {
-      // Task가 있던 Step과 옮길 Step을 찾음
-      const sourceStep = prevSteps.find((s) => s.id === sourceStepId);
-      const destStep = prevSteps.find((s) => s.id === destStepId);
-
-      // Step을 찾지 못했으면 기존 상태 그대로 반환
-      if (!sourceStep || !destStep) return prevSteps;
-
-      // 같은 Step 내에서 이동
-      if (sourceStepId === destStepId) {
-        const taskList = [...sourceStep.items];
-        const [movedTask] = taskList.splice(sourceIndex, 1);
-        if (!movedTask) return prevSteps;
-
-        // slice로 새 배열을 만들어 정확한 위치에 삽입
-        const newTaskList = [
-          ...taskList.slice(0, destIndex),
-          movedTask,
-          ...taskList.slice(destIndex),
-        ];
-
-        const newStep = { ...sourceStep, items: newTaskList };
-        return prevSteps.map((step) => (step.id === sourceStepId ? newStep : step));
-      }
-
-      // Task가 있던 Step에서 Task를 제거
-      const taskList = [...sourceStep.items];
-      const [movedTask] = taskList.splice(sourceIndex, 1);
-
-      // Task를 찾지 못했으면 기존 상태 그대로 반환
-      if (!movedTask) return prevSteps;
-
-      // Task가 제거된 새로운 sourceStep 생성
-      const newSourceStep = { ...sourceStep, items: taskList };
-
-      // Task를 추가할 새로운 destStep 생성
-      const newDestItems = [...destStep.items];
-      newDestItems.splice(destIndex, 0, movedTask); // destIndex 위치에 Task 삽입
-      const newDestStep = { ...destStep, items: newDestItems };
-
-      // 전체 steps 배열을 업데이트
-      // sourceStep과 destStep만 새로운 값으로 교체
-      return prevSteps.map((step) => {
-        if (step.id === sourceStepId) return newSourceStep;
-        if (step.id === destStepId) return newDestStep;
-        return step;
-      });
-    });
-  };
-
   return {
-    steps,
     openStepIds,
     toggleStep,
-    addStep,
-    moveTask,
   };
 }

--- a/src/features/boards/hooks/useTaskItems.ts
+++ b/src/features/boards/hooks/useTaskItems.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Task, UseTaskItemsProps, UseTaskItemsReturn } from '@/types/api/taskItem';
+import { TaskItem, UseTaskItemsProps, UseTaskItemsReturn } from '@/types/api/tasks';
 
 export const useTaskItems = ({ task }: UseTaskItemsProps): UseTaskItemsReturn => {
   // 마감기한이 경과했는지 확인 (완료 상태가 아닌 경우에만)

--- a/src/features/boards/hooks/useTaskItems.ts
+++ b/src/features/boards/hooks/useTaskItems.ts
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import { Task, UseTaskItemsProps, UseTaskItemsReturn } from '@/types/api/taskItem';
+
+export const useTaskItems = ({ task }: UseTaskItemsProps): UseTaskItemsReturn => {
+  // 마감기한이 경과했는지 확인 (완료 상태가 아닌 경우에만)
+  const isDeadlineOverdue = useMemo(() => {
+    if (!task.deadline || task.status === '완료') return false;
+    const deadlineDate = new Date(task.deadline);
+    const today = new Date();
+    return deadlineDate < today;
+  }, [task.deadline, task.status]);
+
+  // 담당자 표시 로직 (최대 3명 + ...)
+  const displayAssignees = useMemo(() => {
+    if (!task.assignee || task.assignee.length === 0) return null;
+
+    const maxDisplay = 3;
+    const displayList = task.assignee.slice(0, maxDisplay);
+    const hasMore = task.assignee.length > maxDisplay;
+
+    return {
+      displayList,
+      hasMore,
+      totalCount: task.assignee.length,
+    };
+  }, [task.assignee]);
+
+  // 카드 높이 조정 (담당자가 없으면 더 작게)
+  const cardHeight = useMemo(() => {
+    return task.assignee && task.assignee.length > 0 ? 'h-[122px]' : 'h-[90px]';
+  }, [task.assignee]);
+
+  // 마감기한 텍스트 색상 결정
+  const deadlineTextColor = useMemo(() => {
+    if (!task.deadline) return 'text-[#898989]';
+    return isDeadlineOverdue ? 'text-red-500' : 'text-[#898989]';
+  }, [task.deadline, isDeadlineOverdue]);
+
+  return {
+    isDeadlineOverdue,
+    displayAssignees,
+    cardHeight,
+    deadlineTextColor,
+  };
+};

--- a/src/hooks/mutations/useCreateStep.ts
+++ b/src/hooks/mutations/useCreateStep.ts
@@ -1,14 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createStep } from '@/services/dashboard/dashboard';
-import { CreateStepRequest } from '@/types/api/dashboard';
+import { CreateStepRequest, CreateStepResponse } from '@/types/api/dashboard';
 
 // STEP 생성 mutation 훅
 export const useCreateStep = () => {
   const queryClient = useQueryClient();
 
-  return useMutation({
-    mutationFn: ({ projectId, body }: { projectId: number; body: CreateStepRequest }) =>
-      createStep(projectId, body),
+  return useMutation<CreateStepResponse, Error, CreateStepRequest>({
+    mutationFn: (request: CreateStepRequest) => createStep(request),
     onSuccess: (data, variables) => {
       // STEP 생성 성공 시 대시보드 데이터 무효화하여 다시 불러오기
       queryClient.invalidateQueries({

--- a/src/hooks/mutations/useCreateStep.ts
+++ b/src/hooks/mutations/useCreateStep.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createStep } from '@/services/dashboard/dashboard';
+import { CreateStepRequest } from '@/types/api/dashboard';
+
+// STEP 생성 mutation 훅
+export const useCreateStep = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ projectId, body }: { projectId: number; body: CreateStepRequest }) =>
+      createStep(projectId, body),
+    onSuccess: (data, variables) => {
+      // STEP 생성 성공 시 대시보드 데이터 무효화하여 다시 불러오기
+      queryClient.invalidateQueries({
+        queryKey: ['dashboard', variables.projectId],
+        exact: false,
+      });
+    },
+  });
+};

--- a/src/hooks/mutations/useCreateStep.ts
+++ b/src/hooks/mutations/useCreateStep.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createStep } from '@/services/dashboard/dashboard';
-import { CreateStepRequest, CreateStepResponse } from '@/types/api/dashboard';
+import { CreateStepRequest, CreateStepResponse } from '@/types/api/steps';
 
 // STEP 생성 mutation 훅
 export const useCreateStep = () => {

--- a/src/hooks/mutations/useCreateTask.ts
+++ b/src/hooks/mutations/useCreateTask.ts
@@ -1,11 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createTask } from '@/services/dashboard/dashboard';
+import { CreateTaskResponse } from '@/types/api/dashboard';
 
 // 업무 생성 mutation 훅
 export const useCreateTask = () => {
   const queryClient = useQueryClient();
 
-  return useMutation({
+  return useMutation<CreateTaskResponse, Error, number>({
     mutationFn: (stepId: number) => createTask(stepId),
     onSuccess: (data, stepId) => {
       // 업무 생성 성공 시 대시보드 데이터 무효화하여 다시 불러오기

--- a/src/hooks/mutations/useCreateTask.ts
+++ b/src/hooks/mutations/useCreateTask.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createTask } from '@/services/dashboard/dashboard';
+
+// 업무 생성 mutation 훅
+export const useCreateTask = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (stepId: number) => createTask(stepId),
+    onSuccess: (data, stepId) => {
+      // 업무 생성 성공 시 대시보드 데이터 무효화하여 다시 불러오기
+      queryClient.invalidateQueries({
+        queryKey: ['dashboard'],
+        exact: false,
+      });
+    },
+  });
+};

--- a/src/hooks/mutations/useCreateTask.ts
+++ b/src/hooks/mutations/useCreateTask.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createTask } from '@/services/dashboard/dashboard';
-import { CreateTaskResponse } from '@/types/api/dashboard';
+import { CreateTaskResponse } from '@/types/api/tasks';
 
 // 업무 생성 mutation 훅
 export const useCreateTask = () => {

--- a/src/hooks/mutations/useDeleteStep.ts
+++ b/src/hooks/mutations/useDeleteStep.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { deleteStep } from '@/services/dashboard/dashboard';
+
+// STEP 삭제 mutation 훅
+export const useDeleteStep = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (stepId: number) => deleteStep(stepId),
+    onSuccess: (data, stepId) => {
+      // STEP 삭제 성공 시 대시보드 데이터 무효화하여 다시 불러오기
+      // 모든 프로젝트의 대시보드 쿼리를 무효화 (어떤 프로젝트의 스텝인지 알 수 없으므로)
+      queryClient.invalidateQueries({
+        queryKey: ['dashboard'],
+        exact: false,
+      });
+    },
+  });
+};

--- a/src/hooks/mutations/useDeleteStep.ts
+++ b/src/hooks/mutations/useDeleteStep.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteStep } from '@/services/dashboard/dashboard';
-import { DeleteStepResponse } from '@/types/api/dashboard';
+import { DeleteStepResponse } from '@/types/api/steps';
 
 // STEP 삭제 mutation 훅
 export const useDeleteStep = () => {

--- a/src/hooks/mutations/useDeleteStep.ts
+++ b/src/hooks/mutations/useDeleteStep.ts
@@ -1,11 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteStep } from '@/services/dashboard/dashboard';
+import { DeleteStepResponse } from '@/types/api/dashboard';
 
 // STEP 삭제 mutation 훅
 export const useDeleteStep = () => {
   const queryClient = useQueryClient();
 
-  return useMutation({
+  return useMutation<DeleteStepResponse, Error, number>({
     mutationFn: (stepId: number) => deleteStep(stepId),
     onSuccess: (data, stepId) => {
       // STEP 삭제 성공 시 대시보드 데이터 무효화하여 다시 불러오기

--- a/src/hooks/mutations/useUpdateStep.ts
+++ b/src/hooks/mutations/useUpdateStep.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { updateStep } from '@/services/dashboard/dashboard';
-import { UpdateStepResponse, UpdateStepRequest } from '@/types/api/dashboard';
+import { UpdateStepResponse, UpdateStepRequest } from '@/types/api/steps';
 
 // STEP 수정 mutation 훅
 export const useUpdateStep = () => {

--- a/src/hooks/mutations/useUpdateStep.ts
+++ b/src/hooks/mutations/useUpdateStep.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateStep } from '@/services/dashboard/dashboard';
+
+// STEP 수정 mutation 훅
+export const useUpdateStep = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ stepId, name }: { stepId: number; name: string }) =>
+      updateStep(stepId, { name }),
+    onSuccess: (data, variables) => {
+      // STEP 수정 성공 시 대시보드 데이터 무효화하여 다시 불러오기
+      queryClient.invalidateQueries({
+        queryKey: ['dashboard'],
+        exact: false,
+      });
+    },
+  });
+};

--- a/src/hooks/mutations/useUpdateStep.ts
+++ b/src/hooks/mutations/useUpdateStep.ts
@@ -1,13 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { updateStep } from '@/services/dashboard/dashboard';
+import { UpdateStepResponse, UpdateStepRequest } from '@/types/api/dashboard';
 
 // STEP 수정 mutation 훅
 export const useUpdateStep = () => {
   const queryClient = useQueryClient();
 
-  return useMutation({
-    mutationFn: ({ stepId, name }: { stepId: number; name: string }) =>
-      updateStep(stepId, { name }),
+  return useMutation<UpdateStepResponse, Error, UpdateStepRequest>({
+    mutationFn: (request: UpdateStepRequest) => updateStep(request),
     onSuccess: (data, variables) => {
       // STEP 수정 성공 시 대시보드 데이터 무효화하여 다시 불러오기
       queryClient.invalidateQueries({

--- a/src/hooks/queries/useGetDashboard.ts
+++ b/src/hooks/queries/useGetDashboard.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { getDashboard } from '@/services/dashboard/dashboard';
+import { GetDashboardRequest } from '@/types/api/dashboard';
+
+// 대시보드 조회 쿼리 훅
+export const useGetDashboard = (params: GetDashboardRequest) => {
+  return useQuery({
+    queryKey: ['dashboard', params.projectId, params.view],
+    queryFn: () => getDashboard(params),
+    enabled: !!params.projectId && !!params.view,
+  });
+};

--- a/src/services/dashboard/dashboard.ts
+++ b/src/services/dashboard/dashboard.ts
@@ -30,3 +30,9 @@ export const createStep = async (
   );
   return data;
 };
+
+// STEP 삭제
+export const deleteStep = async (stepId: number): Promise<string> => {
+  const { data } = await axiosInstance.delete(`/api/v1/steps/${stepId}`);
+  return data;
+};

--- a/src/services/dashboard/dashboard.ts
+++ b/src/services/dashboard/dashboard.ts
@@ -45,3 +45,11 @@ export const updateStep = async (
   const { data } = await axiosInstance.patch<CreateStepResponse>(`/api/v1/steps/${stepId}`, body);
   return data;
 };
+
+// 업무 생성
+export const createTask = async (
+  stepId: number
+): Promise<{ isSuccess: boolean; result: { taskId: number } | null }> => {
+  const { data } = await axiosInstance.post(`/api/v1/tasks`, { stepId });
+  return data;
+};

--- a/src/services/dashboard/dashboard.ts
+++ b/src/services/dashboard/dashboard.ts
@@ -1,14 +1,13 @@
 import axiosInstance from '@/lib/axiosInstance';
+import { GetDashboardRequest, DashboardResponse } from '@/types/api/dashboard';
 import {
-  GetDashboardRequest,
-  DashboardResponse,
   CreateStepRequest,
   CreateStepResponse,
   UpdateStepRequest,
   UpdateStepResponse,
   DeleteStepResponse,
-  CreateTaskResponse,
-} from '@/types/api/dashboard';
+} from '@/types/api/steps';
+import { CreateTaskResponse } from '@/types/api/tasks';
 import { ApiResponse } from '@/types/api/error';
 
 // 프로젝트 대시보드 조회

--- a/src/services/dashboard/dashboard.ts
+++ b/src/services/dashboard/dashboard.ts
@@ -4,12 +4,19 @@ import {
   DashboardResponse,
   CreateStepRequest,
   CreateStepResponse,
+  UpdateStepRequest,
+  UpdateStepResponse,
+  DeleteStepResponse,
+  CreateTaskResponse,
 } from '@/types/api/dashboard';
+import { ApiResponse } from '@/types/api/error';
 
 // 프로젝트 대시보드 조회
 export const getDashboard = async (params: GetDashboardRequest): Promise<DashboardResponse> => {
   const { projectId, view } = params;
-  const response = await axiosInstance.get(`/api/v1/tasks/${projectId}/dashboard?view=${view}`);
+  const response = await axiosInstance.get<ApiResponse<DashboardResponse>>(
+    `/api/v1/tasks/${projectId}/dashboard?view=${view}`
+  );
 
   // API 응답이 { isSuccess, error, result } 형태로 감싸져 있으므로 result에서 실제 데이터 추출
   if (response.data.isSuccess && response.data.result) {
@@ -20,36 +27,32 @@ export const getDashboard = async (params: GetDashboardRequest): Promise<Dashboa
 };
 
 // STEP 생성
-export const createStep = async (
-  projectId: number,
-  body: CreateStepRequest
-): Promise<CreateStepResponse> => {
+export const createStep = async (request: CreateStepRequest): Promise<CreateStepResponse> => {
+  const { projectId, name } = request;
   const { data } = await axiosInstance.post<CreateStepResponse>(
     `/api/v1/projects/${projectId}/steps`,
-    body
+    { name }
   );
   return data;
 };
 
 // STEP 삭제
-export const deleteStep = async (stepId: number): Promise<string> => {
-  const { data } = await axiosInstance.delete(`/api/v1/steps/${stepId}`);
+export const deleteStep = async (stepId: number): Promise<DeleteStepResponse> => {
+  const { data } = await axiosInstance.delete<DeleteStepResponse>(`/api/v1/steps/${stepId}`);
   return data;
 };
 
 // STEP 수정
-export const updateStep = async (
-  stepId: number,
-  body: { name: string }
-): Promise<CreateStepResponse> => {
-  const { data } = await axiosInstance.patch<CreateStepResponse>(`/api/v1/steps/${stepId}`, body);
+export const updateStep = async (request: UpdateStepRequest): Promise<UpdateStepResponse> => {
+  const { stepId, name } = request;
+  const { data } = await axiosInstance.patch<UpdateStepResponse>(`/api/v1/steps/${stepId}`, {
+    name,
+  });
   return data;
 };
 
 // 업무 생성
-export const createTask = async (
-  stepId: number
-): Promise<{ isSuccess: boolean; result: { taskId: number } | null }> => {
-  const { data } = await axiosInstance.post(`/api/v1/tasks`, { stepId });
+export const createTask = async (stepId: number): Promise<CreateTaskResponse> => {
+  const { data } = await axiosInstance.post<CreateTaskResponse>(`/api/v1/tasks`, { stepId });
   return data;
 };

--- a/src/services/dashboard/dashboard.ts
+++ b/src/services/dashboard/dashboard.ts
@@ -1,0 +1,11 @@
+import axiosInstance from '@/lib/axiosInstance';
+import { GetDashboardRequest, DashboardResponse } from '@/types/api/dashboard';
+
+// 프로젝트 대시보드 조회
+export const getDashboard = async (params: GetDashboardRequest): Promise<DashboardResponse> => {
+  const { projectId, view } = params;
+  const { data } = await axiosInstance.get<DashboardResponse>(
+    `/api/v1/tasks/${projectId}/dashboard?view=${view}`
+  );
+  return data;
+};

--- a/src/services/dashboard/dashboard.ts
+++ b/src/services/dashboard/dashboard.ts
@@ -1,11 +1,32 @@
 import axiosInstance from '@/lib/axiosInstance';
-import { GetDashboardRequest, DashboardResponse } from '@/types/api/dashboard';
+import {
+  GetDashboardRequest,
+  DashboardResponse,
+  CreateStepRequest,
+  CreateStepResponse,
+} from '@/types/api/dashboard';
 
 // 프로젝트 대시보드 조회
 export const getDashboard = async (params: GetDashboardRequest): Promise<DashboardResponse> => {
   const { projectId, view } = params;
-  const { data } = await axiosInstance.get<DashboardResponse>(
-    `/api/v1/tasks/${projectId}/dashboard?view=${view}`
+  const response = await axiosInstance.get(`/api/v1/tasks/${projectId}/dashboard?view=${view}`);
+
+  // API 응답이 { isSuccess, error, result } 형태로 감싸져 있으므로 result에서 실제 데이터 추출
+  if (response.data.isSuccess && response.data.result) {
+    return response.data.result;
+  } else {
+    throw new Error('대시보드 데이터를 불러오는데 실패했습니다.');
+  }
+};
+
+// STEP 생성
+export const createStep = async (
+  projectId: number,
+  body: CreateStepRequest
+): Promise<CreateStepResponse> => {
+  const { data } = await axiosInstance.post<CreateStepResponse>(
+    `/api/v1/projects/${projectId}/steps`,
+    body
   );
   return data;
 };

--- a/src/services/dashboard/dashboard.ts
+++ b/src/services/dashboard/dashboard.ts
@@ -36,3 +36,12 @@ export const deleteStep = async (stepId: number): Promise<string> => {
   const { data } = await axiosInstance.delete(`/api/v1/steps/${stepId}`);
   return data;
 };
+
+// STEP 수정
+export const updateStep = async (
+  stepId: number,
+  body: { name: string }
+): Promise<CreateStepResponse> => {
+  const { data } = await axiosInstance.patch<CreateStepResponse>(`/api/v1/steps/${stepId}`, body);
+  return data;
+};

--- a/src/types/api/dashboard.ts
+++ b/src/types/api/dashboard.ts
@@ -1,6 +1,5 @@
 import { ApiResponse, ApiErrorResponse } from './error';
-
-// ===== 대시보드 조회 관련 타입 =====
+import { Step } from './steps';
 
 // 대시보드 조회 요청 타입
 export interface GetDashboardRequest {
@@ -14,78 +13,4 @@ export interface DashboardResponse {
   projectName: string;
   steps: Step[];
   totalCount: number;
-}
-
-// ===== STEP 관련 타입 =====
-
-// STEP 생성 요청 타입
-export interface CreateStepRequest {
-  projectId: number;
-  name: string;
-}
-
-// STEP 생성 응답 타입
-export interface CreateStepResponse {
-  isSuccess: boolean;
-  error: ApiErrorResponse | null;
-  result: {
-    stepId: number;
-    name: string;
-  } | null;
-}
-
-// STEP 수정 요청 타입
-export interface UpdateStepRequest {
-  stepId: number;
-  name: string;
-}
-
-// STEP 수정 응답 타입 (CreateStepResponse와 동일)
-export type UpdateStepResponse = CreateStepResponse;
-
-// STEP 삭제 응답 타입
-export interface DeleteStepResponse {
-  isSuccess: boolean;
-  error: ApiErrorResponse | null;
-  result: string | null; // "step 삭제 성공" 메시지
-}
-
-// ===== TASK 관련 타입 =====
-
-// TASK 생성 요청 타입
-export interface CreateTaskRequest {
-  stepId: number;
-}
-
-// TASK 생성 응답 타입
-export interface CreateTaskResponse {
-  isSuccess: boolean;
-  error: ApiErrorResponse | null;
-  result: {
-    taskId: number;
-  } | null;
-}
-
-// ===== 공통 타입 =====
-
-// 단계 타입
-export interface Step {
-  stepId: number;
-  stepName: string;
-  tasks: Task[];
-}
-
-// 업무 타입
-export interface Task {
-  taskId: number;
-  taskName: string;
-  status: 'ONGOING' | 'COMPLETED' | 'PENDING';
-  managers: Manager[];
-  deadline: string;
-}
-
-// 담당자 타입
-export interface Manager {
-  userId: number;
-  userName: string;
 }

--- a/src/types/api/dashboard.ts
+++ b/src/types/api/dashboard.ts
@@ -1,5 +1,6 @@
 import { ApiResponse, ApiErrorResponse } from './error';
 import { Step } from './steps';
+import { Task } from './tasks';
 
 // 대시보드 조회 요청 타입
 export interface GetDashboardRequest {
@@ -7,10 +8,27 @@ export interface GetDashboardRequest {
   view: 'step' | 'status';
 }
 
-// 대시보드 응답 타입
-export interface DashboardResponse {
+// 상태별 그룹 타입
+export interface StatusGroup {
+  status: 'NOTSTART' | 'ONGOING' | 'COMPLETED';
+  tasks: Task[];
+}
+
+// STEP 뷰 응답 타입
+export interface StepViewResponse {
   projectId: number;
   projectName: string;
   steps: Step[];
   totalCount: number;
 }
+
+// STATUS 뷰 응답 타입
+export interface StatusViewResponse {
+  projectId: number;
+  projectName: string;
+  statusGroups: StatusGroup[];
+  totalCount: number;
+}
+
+// 대시보드 응답 타입 (유니온 타입)
+export type DashboardResponse = StepViewResponse | StatusViewResponse;

--- a/src/types/api/dashboard.ts
+++ b/src/types/api/dashboard.ts
@@ -1,0 +1,35 @@
+// 대시보드 조회 요청 타입
+export interface GetDashboardRequest {
+  projectId: number;
+  view: 'step' | 'status';
+}
+
+// 대시보드 응답 타입
+export interface DashboardResponse {
+  projectId: number;
+  projectName: string;
+  steps: Step[];
+  totalCount: number;
+}
+
+// 단계 타입
+export interface Step {
+  stepId: number;
+  stepName: string;
+  tasks: Task[];
+}
+
+// 업무 타입
+export interface Task {
+  taskId: number;
+  taskName: string;
+  status: 'ONGOING' | 'COMPLETED' | 'PENDING';
+  managers: Manager[];
+  deadline: string;
+}
+
+// 담당자 타입
+export interface Manager {
+  userId: number;
+  userName: string;
+}

--- a/src/types/api/dashboard.ts
+++ b/src/types/api/dashboard.ts
@@ -33,3 +33,22 @@ export interface Manager {
   userId: number;
   userName: string;
 }
+
+// STEP 생성 요청 타입
+export interface CreateStepRequest {
+  name: string;
+}
+
+// STEP 생성 응답 타입
+export interface CreateStepResponse {
+  isSuccess: boolean;
+  error: {
+    errorCode: string;
+    reason: string;
+    data: null;
+  } | null;
+  result: {
+    stepId: number;
+    name: string;
+  } | null;
+}

--- a/src/types/api/dashboard.ts
+++ b/src/types/api/dashboard.ts
@@ -1,3 +1,7 @@
+import { ApiResponse, ApiErrorResponse } from './error';
+
+// ===== 대시보드 조회 관련 타입 =====
+
 // 대시보드 조회 요청 타입
 export interface GetDashboardRequest {
   projectId: number;
@@ -11,6 +15,58 @@ export interface DashboardResponse {
   steps: Step[];
   totalCount: number;
 }
+
+// ===== STEP 관련 타입 =====
+
+// STEP 생성 요청 타입
+export interface CreateStepRequest {
+  projectId: number;
+  name: string;
+}
+
+// STEP 생성 응답 타입
+export interface CreateStepResponse {
+  isSuccess: boolean;
+  error: ApiErrorResponse | null;
+  result: {
+    stepId: number;
+    name: string;
+  } | null;
+}
+
+// STEP 수정 요청 타입
+export interface UpdateStepRequest {
+  stepId: number;
+  name: string;
+}
+
+// STEP 수정 응답 타입 (CreateStepResponse와 동일)
+export type UpdateStepResponse = CreateStepResponse;
+
+// STEP 삭제 응답 타입
+export interface DeleteStepResponse {
+  isSuccess: boolean;
+  error: ApiErrorResponse | null;
+  result: string | null; // "step 삭제 성공" 메시지
+}
+
+// ===== TASK 관련 타입 =====
+
+// TASK 생성 요청 타입
+export interface CreateTaskRequest {
+  stepId: number;
+}
+
+// TASK 생성 응답 타입
+export interface CreateTaskResponse {
+  isSuccess: boolean;
+  error: ApiErrorResponse | null;
+  result: {
+    taskId: number;
+  } | null;
+}
+
+// ===== 공통 타입 =====
 
 // 단계 타입
 export interface Step {
@@ -32,23 +88,4 @@ export interface Task {
 export interface Manager {
   userId: number;
   userName: string;
-}
-
-// STEP 생성 요청 타입
-export interface CreateStepRequest {
-  name: string;
-}
-
-// STEP 생성 응답 타입
-export interface CreateStepResponse {
-  isSuccess: boolean;
-  error: {
-    errorCode: string;
-    reason: string;
-    data: null;
-  } | null;
-  result: {
-    stepId: number;
-    name: string;
-  } | null;
 }

--- a/src/types/api/error.ts
+++ b/src/types/api/error.ts
@@ -1,19 +1,13 @@
-// API 응답의 error 객체 내부 타입
-export interface ApiErrorPayload {
-  errorCode: string; // 'PROJECT4043' 등
-  reason: string; // "유효기간이 지난 url입니다." 등
-  data: null; // data가 있을 경우를 대비
+// API 에러 응답 타입
+export interface ApiErrorResponse {
+  errorCode: string;
+  reason: string;
+  data: null;
 }
 
-// 실패했을 때의 전체 API 응답 타입
-export interface ApiErrorResponse {
-  isSuccess: false;
-  error: ApiErrorPayload;
-  result: {
-    project?: {
-      id?: string;
-      name?: string;
-      leader?: string;
-    };
-  };
+// 공통 API 응답 래퍼 타입
+export interface ApiResponse<T> {
+  isSuccess: boolean;
+  error: ApiErrorResponse | null;
+  result: T | null;
 }

--- a/src/types/api/project.ts
+++ b/src/types/api/project.ts
@@ -1,3 +1,5 @@
+import { ApiErrorResponse } from './error';
+
 export interface CreateProjectRequest {
   name: string;
   permission?: string; // 생성자의 권한 (LEAD로 설정)
@@ -5,13 +7,13 @@ export interface CreateProjectRequest {
 
 export interface CreateProjectReponse {
   isSuccess: boolean;
-  error: string;
+  error: ApiErrorResponse | null;
   result: {
     id: string;
     name: string;
     inviteCode: string;
     expiresAt: string;
-  };
+  } | null;
 }
 
 export interface GetJoinProjectRequest {
@@ -20,18 +22,14 @@ export interface GetJoinProjectRequest {
 
 export interface GetJoinProjectResponse {
   isSuccess: boolean;
-  error: {
-    errorCode: string;
-    reason: string;
-    data: null;
-  };
+  error: ApiErrorResponse | null;
   result: {
     project?: {
       id: string;
       name: string;
       leader: string;
     };
-  };
+  } | null;
 }
 
 export interface PostJoinProjectRequest {
@@ -40,8 +38,8 @@ export interface PostJoinProjectRequest {
 
 export interface PostJoinProjectResponse {
   isSuccess: boolean;
-  error: string | null;
+  error: ApiErrorResponse | null;
   result?: {
     message?: string;
-  };
+  } | null;
 }

--- a/src/types/api/steps.ts
+++ b/src/types/api/steps.ts
@@ -1,0 +1,40 @@
+import { ApiErrorResponse } from './error';
+import { Task } from './tasks';
+
+// STEP 생성 요청 타입
+export interface CreateStepRequest {
+  projectId: number;
+  name: string;
+}
+
+// STEP 생성 응답 타입
+export interface CreateStepResponse {
+  isSuccess: boolean;
+  error: ApiErrorResponse | null;
+  result: {
+    stepId: number;
+    name: string;
+  } | null;
+}
+
+// STEP 수정 요청 타입
+export interface UpdateStepRequest {
+  stepId: number;
+  name: string;
+}
+
+// STEP 수정 응답 타입 (CreateStepResponse와 동일)
+export type UpdateStepResponse = CreateStepResponse;
+
+// STEP 삭제 응답 타입
+export interface DeleteStepResponse {
+  isSuccess: boolean;
+  error: ApiErrorResponse | null;
+  result: string | null; // "step 삭제 성공" 메시지
+}
+
+export interface Step {
+  stepId: number;
+  stepName: string;
+  tasks: Task[];
+}

--- a/src/types/api/taskDetail.ts
+++ b/src/types/api/taskDetail.ts
@@ -1,3 +1,5 @@
+import { ApiErrorResponse } from './error';
+
 // 공통 타입 정의
 interface Manager {
   userId: number;
@@ -8,17 +10,10 @@ interface FileItem {
   fileUrl: string;
 }
 
-// 에러 응답 타입 정의
-interface ErrorResponse {
-  errorCode: string; // 예: "TASK4041"
-  reason: string; // 예: "TASK를 찾을 수 없습니다."
-  data: null;
-}
-
 // 업무 상세 조회 API 응답 타입 정의
 export interface TaskDetailResponse {
   isSuccess: boolean;
-  error: ErrorResponse | null;
+  error: ApiErrorResponse | null;
   result: {
     name: string;
     deadline: string; // 예: '2024-07-10 00:00:00'
@@ -44,7 +39,7 @@ export interface UpdateTaskRequest {
 // 업무 수정 API 응답 타입 정의
 export interface UpdateTaskResponse {
   isSuccess: boolean;
-  error: null;
+  error: ApiErrorResponse | null;
   result: {
     name: string;
     deadline: string;
@@ -58,7 +53,7 @@ export interface UpdateTaskResponse {
 // 업무 삭제 API 응답 타입 정의
 export interface DeleteTaskResponse {
   isSuccess: boolean;
-  error: null;
+  error: ApiErrorResponse | null;
   result: {
     message: string; // "업무가 성공적으로 삭제되었습니다."
     taskId: string; // 삭제된 업무의 ID

--- a/src/types/api/taskItem.ts
+++ b/src/types/api/taskItem.ts
@@ -1,0 +1,58 @@
+// TaskItem 컴포넌트 관련 타입 정의
+
+// 기본 Task 인터페이스
+export interface Task {
+  id: number;
+  title: string;
+  status: string;
+  deadline?: string;
+  assignee?: string[];
+}
+
+// TaskItem 컴포넌트 Props
+export interface TaskItemProps {
+  id: number;
+  title: string;
+  status: string; // 유연성을 위해 string으로 변경
+  deadline?: string;
+  assignee?: string[];
+}
+
+// TaskItem 컴포넌트 Props (projectId 포함)
+export interface TaskItemComponentProps extends TaskItemProps {
+  projectId: string;
+}
+
+// useTaskItems 훅 Props
+export interface UseTaskItemsProps {
+  task: Task;
+}
+
+// useTaskItems 훅 반환값
+export interface UseTaskItemsReturn {
+  isDeadlineOverdue: boolean;
+  displayAssignees: {
+    displayList: string[];
+    hasMore: boolean;
+    totalCount: number;
+  } | null;
+  cardHeight: string;
+  deadlineTextColor: string;
+}
+
+// Task 상태 매핑 타입
+export type TaskStatus = 'BEFORE' | 'ONGOING' | 'COMPLETE';
+
+// Task 상태 표시 텍스트 매핑
+export const TASK_STATUS_DISPLAY: Record<TaskStatus, string> = {
+  BEFORE: '시작 전',
+  ONGOING: '진행 중',
+  COMPLETE: '완료',
+} as const;
+
+// Task 상태별 스타일 매핑
+export const TASK_STATUS_STYLES: Record<string, { bg: string; text: string }> = {
+  '진행 중': { bg: 'bg-[#B6F5DF]', text: 'text-[#505050]' },
+  완료: { bg: 'bg-[#D1D5DB]', text: 'text-[#505050]' },
+  '시작 전': { bg: 'bg-[#E7E7E7]', text: 'text-[#505050]' },
+} as const;

--- a/src/types/api/tasks.ts
+++ b/src/types/api/tasks.ts
@@ -1,7 +1,36 @@
-// TaskItem 컴포넌트 관련 타입 정의
+import { ApiErrorResponse } from './error';
 
-// 기본 Task 인터페이스
+// API용 Task 타입 (완전한 형태)
 export interface Task {
+  taskId: number;
+  taskName: string;
+  status: 'ONGOING' | 'COMPLETED' | 'PENDING';
+  managers: Manager[];
+  deadline: string;
+}
+
+// 담당자 타입
+export interface Manager {
+  userId: number;
+  userName: string;
+}
+
+// TASK 생성 요청 타입
+export interface CreateTaskRequest {
+  stepId: number;
+}
+
+// TASK 생성 응답 타입
+export interface CreateTaskResponse {
+  isSuccess: boolean;
+  error: ApiErrorResponse | null;
+  result: {
+    taskId: number;
+  } | null;
+}
+
+// UI용 Task 타입 (간단한 형태)
+export interface TaskItem {
   id: number;
   title: string;
   status: string;
@@ -10,13 +39,7 @@ export interface Task {
 }
 
 // TaskItem 컴포넌트 Props
-export interface TaskItemProps {
-  id: number;
-  title: string;
-  status: string; // 유연성을 위해 string으로 변경
-  deadline?: string;
-  assignee?: string[];
-}
+export interface TaskItemProps extends TaskItem {}
 
 // TaskItem 컴포넌트 Props (projectId 포함)
 export interface TaskItemComponentProps extends TaskItemProps {
@@ -25,7 +48,7 @@ export interface TaskItemComponentProps extends TaskItemProps {
 
 // useTaskItems 훅 Props
 export interface UseTaskItemsProps {
-  task: Task;
+  task: TaskItem;
 }
 
 // useTaskItems 훅 반환값
@@ -40,17 +63,17 @@ export interface UseTaskItemsReturn {
   deadlineTextColor: string;
 }
 
-// Task 상태 매핑 타입
+// TASK 상태 매핑 타입
 export type TaskStatus = 'BEFORE' | 'ONGOING' | 'COMPLETE';
 
-// Task 상태 표시 텍스트 매핑
+// TASK 상태 표시 텍스트 매핑
 export const TASK_STATUS_DISPLAY: Record<TaskStatus, string> = {
   BEFORE: '시작 전',
   ONGOING: '진행 중',
   COMPLETE: '완료',
 } as const;
 
-// Task 상태별 스타일 매핑
+// TASK 상태별 스타일 매핑
 export const TASK_STATUS_STYLES: Record<string, { bg: string; text: string }> = {
   '진행 중': { bg: 'bg-[#B6F5DF]', text: 'text-[#505050]' },
   완료: { bg: 'bg-[#D1D5DB]', text: 'text-[#505050]' },

--- a/src/types/api/user.ts
+++ b/src/types/api/user.ts
@@ -1,3 +1,5 @@
+import { ApiErrorResponse } from './error';
+
 export interface UserProject {
   id: string;
   name: string;
@@ -18,13 +20,13 @@ export interface UserProfile {
 // 사용자 프로필 API 응답 구조
 export interface UserResponse {
   isSuccess: boolean;
-  error: null;
-  result: UserProfile;
+  error: ApiErrorResponse | null;
+  result: UserProfile | null;
 }
 
 // 사용자 프로젝트 API 응답 구조
 export interface UserProjectsResponse {
   isSuccess: boolean;
-  error: null;
-  result: UserProject[];
+  error: ApiErrorResponse | null;
+  result: UserProject[] | null;
 }

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -1,4 +1,4 @@
-import { Step } from '@/types/api/dashboard';
+import { Step } from '@/types/api/steps';
 
 export interface BoardProps {
   steps: Step[];

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -1,6 +1,12 @@
 import { Step } from '@/types/api/steps';
+import { StatusGroup } from '@/types/api/dashboard';
 
-export interface BoardProps {
+export interface StepsBoardProps {
   steps: Step[];
+  projectId: string;
+}
+
+export interface StatusBoardProps {
+  statusGroups: StatusGroup[];
   projectId: string;
 }

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -1,4 +1,4 @@
-import { Step } from '@/constants/mockData';
+import { Step } from '@/types/api/dashboard';
 
 export interface BoardProps {
   steps: Step[];


### PR DESCRIPTION
## 연관 이슈
- Closes #108 

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
- 대시보드 조회 - STEP별
- 대시보드 조회 - 진행상황별
- STEP 생성
- STEP 수정
- STEP 삭제
- 업무 추가
- 상기 기능들 추가하였습니다. 또한 공통 응답/요청 타입과 공통 에러 타입을 정의해 각 서비스 함수에서 사용할 수 있도록 하였습니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 전달할 내용은 [노션 개인페이지](https://www.notion.so/API-24166be5909b80c7ad84eafbe307d641?source=copy_link)에 적어두었습니다.
- UI 개선 사항 반영 및 검색, 필터 기능은 주말 동안 구현할 예정입니다.

## 첨부 자료
-
