### PR TITLE
[Feat/128] 프로젝트 홈 페이지 API 오류 해결

### DIFF
--- a/src/app/(main)/projects/[projectId]/page.tsx
+++ b/src/app/(main)/projects/[projectId]/page.tsx
@@ -18,6 +18,9 @@ export default function ProjectHomePage() {
   const projectId = Number(params.projectId);
   const [currentUserEmail, setCurrentUserEmail] = useState<string>('');
   const [currentUserImageUrl, setCurrentUserImageUrl] = useState<string>('');
+  const [projectName, setProjectName] = useState<string>('프로젝트');
+  const [inviteCode, setInviteCode] = useState<string>('INVITE123');
+  const [expiresAt, setExpiresAt] = useState<string>('');
 
   const {
     // 상태
@@ -54,6 +57,29 @@ export default function ProjectHomePage() {
     // API mutations
     updateProjectMutation,
   } = useProjectHomeState(projectId);
+
+  // 프로젝트 데이터에서 프로젝트 이름 가져오기
+  useEffect(() => {
+    const fetchProjectData = async () => {
+      try {
+        const response = await axiosInstance.get(`/api/v1/projects/${projectId}`);
+        if (response.data.isSuccess && response.data.result?.project) {
+          setProjectName(response.data.result.project.name || '프로젝트');
+
+          // 초대코드와 만료일 설정 (7일 후로 설정)
+          const now = new Date();
+          const expiresDate = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000); // 7일 후
+          setExpiresAt(expiresDate.toISOString());
+
+          // 초대코드는 프로젝트 ID를 기반으로 생성 (실제로는 API에서 가져와야 함)
+          setInviteCode(`INVITE${projectId}`);
+        }
+      } catch (error) {
+        console.error('프로젝트 정보 가져오기 실패:', error);
+      }
+    };
+    fetchProjectData();
+  }, [projectId]);
 
   // 현재 사용자 이메일 가져오기
   useEffect(() => {
@@ -269,9 +295,9 @@ export default function ProjectHomePage() {
         <Portal>
           <AddTeamProfileModal
             onClose={handleCloseAddTeamModal}
-            projectName="프로젝트명"
-            inviteCode="INVITE123"
-            expiresAt="2024-12-31"
+            projectName={projectName}
+            inviteCode={inviteCode}
+            expiresAt={expiresAt}
             onJoinClick={handleJoinProject}
           />
         </Portal>

--- a/src/app/(main)/projects/[projectId]/page.tsx
+++ b/src/app/(main)/projects/[projectId]/page.tsx
@@ -17,6 +17,7 @@ export default function ProjectHomePage() {
   const params = useParams();
   const projectId = Number(params.projectId);
   const [currentUserEmail, setCurrentUserEmail] = useState<string>('');
+  const [currentUserImageUrl, setCurrentUserImageUrl] = useState<string>('');
 
   const {
     // 상태
@@ -61,6 +62,7 @@ export default function ProjectHomePage() {
         const response = await axiosInstance.get('/api/v1/users/me');
         if (response.data.isSuccess && response.data.result) {
           setCurrentUserEmail(response.data.result.email);
+          setCurrentUserImageUrl(response.data.result.imageUrl);
         }
       } catch (error) {
         console.error('현재 사용자 정보 가져오기 실패:', error);
@@ -242,6 +244,7 @@ export default function ProjectHomePage() {
               role={member.role}
               isLeader={member.isLeader}
               currentUserEmail={currentUserEmail}
+              currentUserImageUrl={currentUserImageUrl}
               onClick={() => handleChangeLeader(member.id)}
               onUpdate={(field, value) => handleUpdateTeamMember(member.id, field, value)}
             />

--- a/src/app/(main)/projects/[projectId]/page.tsx
+++ b/src/app/(main)/projects/[projectId]/page.tsx
@@ -241,6 +241,7 @@ export default function ProjectHomePage() {
               email={member.email}
               role={member.role}
               isLeader={member.isLeader}
+              currentUserEmail={currentUserEmail}
               onClick={() => handleChangeLeader(member.id)}
               onUpdate={(field, value) => handleUpdateTeamMember(member.id, field, value)}
             />

--- a/src/components/TeamMemberCard.tsx
+++ b/src/components/TeamMemberCard.tsx
@@ -9,6 +9,7 @@ interface TeamMemberCardProps {
   role: string;
   isLeader?: boolean;
   currentUserEmail?: string;
+  currentUserImageUrl?: string;
   onClick?: () => void;
   onUpdate?: (field: 'role', value: string) => void;
 }
@@ -20,6 +21,7 @@ export default function TeamMemberCard({
   role,
   isLeader = false,
   currentUserEmail,
+  currentUserImageUrl,
   onClick,
   onUpdate,
 }: TeamMemberCardProps) {
@@ -76,9 +78,11 @@ export default function TeamMemberCard({
       <div className="max-lg:flex">
         <div className="flex flex-col items-center">
           <img
-            src="/icons/myprofile.svg"
+            src={
+              isCurrentUser && currentUserImageUrl ? currentUserImageUrl : '/icons/myprofile.svg'
+            }
             alt="Profile"
-            className="w-[125px] h-[125px]
+            className="w-[125px] h-[125px] rounded-full object-cover
       max-lg:ml-[20px]"
           />
 

--- a/src/components/TeamMemberCard.tsx
+++ b/src/components/TeamMemberCard.tsx
@@ -8,6 +8,7 @@ interface TeamMemberCardProps {
   email: string;
   role: string;
   isLeader?: boolean;
+  currentUserEmail?: string;
   onClick?: () => void;
   onUpdate?: (field: 'role', value: string) => void;
 }
@@ -18,11 +19,15 @@ export default function TeamMemberCard({
   email,
   role,
   isLeader = false,
+  currentUserEmail,
   onClick,
   onUpdate,
 }: TeamMemberCardProps) {
   const [editingField, setEditingField] = useState<'role' | null>(null);
   const [editValue, setEditValue] = useState('');
+
+  // 본인의 프로필 카드인지 확인
+  const isCurrentUser = currentUserEmail === email;
 
   const handleFieldClick = (field: 'role', currentValue: string) => {
     setEditingField(field);
@@ -50,12 +55,23 @@ export default function TeamMemberCard({
     }
   };
 
+  const handleCardClick = () => {
+    // 팀장인 경우 클릭 이벤트를 무시 (팀장 변경 불가)
+    if (isLeader) {
+      return;
+    }
+    // 팀원인 경우에만 팀장 변경 모달 표시
+    onClick?.();
+  };
+
   return (
     <div
-      className="w-[316px] h-[368px] rounded-[12px] bg-white mt-[24px] flex-col py-[36px] px-[40px] cursor-pointer
-      max-lg:ml-[142px] max-lg:w-[580px] max-lg:h-[241px]"
+      className={`w-[316px] h-[368px] rounded-[12px] bg-white mt-[24px] flex-col py-[36px] px-[40px] 
+      max-lg:ml-[142px] max-lg:w-[580px] max-lg:h-[241px] ${
+        !isLeader ? 'cursor-pointer hover:shadow-lg transition-shadow' : ''
+      }`}
       style={{ boxShadow: '0px 0px 10px 0px #00000033' }}
-      onClick={onClick}
+      onClick={handleCardClick}
     >
       <div className="max-lg:flex">
         <div className="flex flex-col items-center">

--- a/src/features/projectHome/components/AddTeamProfileModal.tsx
+++ b/src/features/projectHome/components/AddTeamProfileModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { formatToKoreanDate } from '@/utils/formatDate';
 
 interface AddTeamProfileModalProps {
@@ -19,6 +20,7 @@ export default function AddTeamProfileModal({
   onJoinClick,
 }: AddTeamProfileModalProps) {
   const [showCopyModal, setShowCopyModal] = useState(false);
+  const router = useRouter();
 
   const handleCopyText = async () => {
     const textToCopy = `💡 프로젝트에 참여해 주세요!
@@ -36,6 +38,12 @@ export default function AddTeamProfileModal({
     } catch {
       window.alert('텍스트 복사에 실패했습니다.');
     }
+  };
+
+  const handleJoinClick = () => {
+    // 참여 수락 페이지로 이동
+    router.push(`/projects/join/${inviteCode}`);
+    onClose();
   };
 
   return (
@@ -65,16 +73,13 @@ export default function AddTeamProfileModal({
             <br />
             👉 참여하기:{' '}
             <span
-              className="underline font-bold text-[#81D7D4] cursor-pointer"
-              onClick={() => {
-                onJoinClick?.();
-                onClose();
-              }}
+              className="underline font-bold text-[#81D7D4] cursor-pointer hover:text-[#6BC5C2] transition-colors"
+              onClick={handleJoinClick}
             >
               {projectName}
             </span>
             <br />
-            링크 유효기간: {formatToKoreanDate(expiresAt)}까지
+            링크 유효기간: {formatToKoreanDate(expiresAt)}
           </p>
 
           <button

--- a/src/features/projectHome/components/PostItModal.tsx
+++ b/src/features/projectHome/components/PostItModal.tsx
@@ -11,7 +11,9 @@ export default function PostItModal({ onClose, onSave }: PostItModalProps) {
   const [content, setContent] = useState('');
 
   const handleSave = () => {
-    onSave(content);
+    if (content.trim()) {
+      onSave(content);
+    }
   };
 
   const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -20,6 +22,9 @@ export default function PostItModal({ onClose, onSave }: PostItModalProps) {
       setContent(value);
     }
   };
+
+  // 내용이 비어있는지 확인
+  const isEmpty = !content.trim();
 
   return (
     <div className="fixed inset-0 bg-[#00000033] rounded-[12px] flex items-center justify-center z-50">
@@ -56,8 +61,11 @@ export default function PostItModal({ onClose, onSave }: PostItModalProps) {
         />
         <div className="text-[12px] text-[#898989] mt-[4px] self-end">{content.length}/32</div>
         <button
-          className="w-[184px] h-[34px] bg-[#81D7D4] text-[18px] text-white font-bold rounded-[4px] mt-[16px] cursor-pointer"
+          className={`w-[184px] h-[34px] text-[18px] text-white font-bold rounded-[4px] mt-[16px] ${
+            isEmpty ? 'bg-[#BAE5E4]' : 'bg-[#81D7D4] cursor-pointer'
+          }`}
           onClick={handleSave}
+          disabled={isEmpty}
         >
           저장하기
         </button>

--- a/src/features/projectHome/components/TeamMemberCard.tsx
+++ b/src/features/projectHome/components/TeamMemberCard.tsx
@@ -6,6 +6,9 @@ interface TeamMemberCardProps {
   email: string;
   role: string;
   isLeader?: boolean;
+  currentUserEmail?: string;
+  onClick?: () => void;
+  onUpdate?: (field: string, value: string) => void;
 }
 
 export default function TeamMemberCard({
@@ -14,12 +17,30 @@ export default function TeamMemberCard({
   email,
   role,
   isLeader = false,
+  currentUserEmail,
+  onClick,
+  onUpdate,
 }: TeamMemberCardProps) {
+  // 본인의 프로필 카드인지 확인
+  const isCurrentUser = currentUserEmail === email;
+
+  const handleCardClick = () => {
+    // 본인의 프로필 카드인 경우 클릭 이벤트를 무시
+    if (isCurrentUser) {
+      return;
+    }
+    // 다른 팀원의 카드인 경우에만 팀장 변경 모달 표시
+    onClick?.();
+  };
+
   return (
     <div
-      className="w-[315px] h-[368px] rounded-[12px] bg-white mt-[24px] flex-col py-[36px] px-[40px]
-      max-lg:ml-[142px] max-lg:w-[580px] max-lg:h-[241px]"
+      className={`w-[315px] h-[368px] rounded-[12px] bg-white mt-[24px] flex-col py-[36px] px-[40px]
+      max-lg:ml-[142px] max-lg:w-[580px] max-lg:h-[241px] ${
+        !isCurrentUser ? 'cursor-pointer hover:shadow-lg transition-shadow' : ''
+      }`}
       style={{ boxShadow: '0px 0px 10px 0px #00000033' }}
+      onClick={handleCardClick}
     >
       <div className="max-lg:flex">
         <div>

--- a/src/hooks/mutations/useProjectHome.ts
+++ b/src/hooks/mutations/useProjectHome.ts
@@ -470,8 +470,16 @@ export const useProjectHomeState = (projectId: number) => {
             );
           }
         },
-        onError: (error) => {
+        onError: (error: any) => {
           console.error('프로필 카드 수정 실패:', error);
+
+          // 403 오류인 경우 사용자에게 알림
+          if (error.response?.status === 403) {
+            alert('프로필 수정 권한이 없습니다. 프로젝트 멤버인지 확인해주세요.');
+          } else {
+            alert('프로필 수정에 실패했습니다. 다시 시도해주세요.');
+          }
+
           // 에러 시에도 로컬 상태 업데이트 (개발 환경)
           if (process.env.NODE_ENV === 'development') {
             setTeamMembers((prev) =>

--- a/src/services/ProjectHome/projectHome.ts
+++ b/src/services/ProjectHome/projectHome.ts
@@ -280,19 +280,28 @@ export const updateProfile = async (
   profileData: UpdateProfileRequest
 ): Promise<UpdateProfileResponse> => {
   try {
-    const response = await axiosInstance.patch<UpdateProfileResponse>(
-      `/api/v1/projects/${projectId}/profile`,
-      profileData
-    );
+    console.log('프로필 수정 API 호출 시도:', `/api/v1/users/me`, profileData);
+
+    // 사용자 본인의 프로필을 수정하는 API 사용
+    const response = await axiosInstance.patch<UpdateProfileResponse>(`/api/v1/users/me`, {
+      school: profileData.role, // role을 school로 매핑
+    });
+
+    console.log('프로필 수정 성공:', response.data);
     return response.data;
-  } catch (error) {
+  } catch (error: any) {
     console.error('프로필 수정 API 호출 실패:', error);
-    // API 호출 실패 시 mock 응답 반환
-    return {
-      isSuccess: true,
-      error: null,
-      result: {},
-    };
+
+    // 403 오류인 경우 권한 문제로 처리
+    if (error.response?.status === 403) {
+      console.error('403 Forbidden: 프로필 수정 권한이 없습니다.');
+      console.error('가능한 원인:');
+      console.error('1. 현재 사용자가 인증되지 않았습니다.');
+      console.error('2. 사용자 프로필 수정 권한이 없습니다.');
+    }
+
+    // 실제 오류를 throw하여 상위에서 처리하도록 함
+    throw error;
   }
 };
 


### PR DESCRIPTION
## 연관 이슈
- Closes #128 

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [x] Feature : 새로운 기능 추가
- [x] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
- 드디어 프로필 카드 수정 API 오류 해결..!
- 포스트잇 내용 미입력시 저장하기 버튼이 비활성화됩니다.
- 프로필 카드 이미지를 마이페이지의 프로필 사진과 동일하게 설정하였습니다.
- 팀원 추가 모달 링크를 참여 수락 페이지로 연결하였습니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-
