### PR TITLE
[Feat/157] 팀캘린더 드래그앤 드롭, 업무 대시 보드 마감일, 프로젝트 생성일 기준 일정 생성 기능 추가

### DIFF
--- a/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
+++ b/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
@@ -6,6 +6,7 @@ import { Calendar as BigCalendar, momentLocalizer, Views } from 'react-big-calen
 import moment from 'moment';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import CustomDateCellWrapper from '@/features/teamclendar/CustomDateCellWrapper';
+import axiosInstance from '@/lib/axiosInstance';
 import CalendarEventBox from '@/features/teamclendar/components/CalendarEventBox';
 import { useGetCalendarPlans } from '@/hooks/queries/useGetTeamCalendar';
 
@@ -13,6 +14,7 @@ const localizer = momentLocalizer(moment);
 
 export default function TeamCalendar() {
   const [currentDate, setCurrentDate] = useState(new Date());
+  const [projectCreatedAtISO, setProjectCreatedAtISO] = useState<string | undefined>(undefined);
   const router = useRouter();
   const params = useParams();
   const projectId = params.projectId?.toString();
@@ -42,6 +44,26 @@ export default function TeamCalendar() {
       window.removeEventListener('focus', handleFocus);
     };
   }, [refetch]);
+
+  // 프로젝트 생성일을 조회해 해당 일 이전 날짜 차단
+  useEffect(() => {
+    const fetchProjectMeta = async () => {
+      try {
+        if (!projectId) return;
+        const { data } = await axiosInstance.get(`/api/v1/projects/${projectId}`);
+        const createdAt = data?.result?.project?.createdAt || data?.result?.createdAt;
+        if (createdAt) {
+          // 날짜 비교 오차 방지를 위해 'YYYY-MM-DD'로 전달 (타임존 영향 제거)
+          const creationDay = moment(createdAt).format('YYYY-MM-DD');
+          setProjectCreatedAtISO(creationDay);
+        }
+      } catch (e) {
+        // 생성일을 못 가져오면 제한 없이 동작
+        setProjectCreatedAtISO(undefined);
+      }
+    };
+    fetchProjectMeta();
+  }, [projectId]);
 
   // Calendar 표시용 events 가공 (timezone-safe)
   const events =
@@ -96,7 +118,7 @@ export default function TeamCalendar() {
               end = new Date(start.getTime() + 60 * 1000);
             }
           } else {
-            // 포맷 예측 실패 시 안전 fallback
+            // 포맷 예측 실패 시 안전 fallback (0분 이벤트 방지: +1분)
             start = new Date();
             end = new Date(start.getTime() + 60 * 1000);
           }
@@ -122,8 +144,15 @@ export default function TeamCalendar() {
     console.log('일정 반영 확인:', events);
   }, [events]);
 
-  const handleEventClick = (event: { id: string }) => {
-    router.push(`/projects/${projectId}/teamcalendar/${event.id}/teamtask`);
+  const handleEventClick = (event: { id: string; title?: string }) => {
+    const target = `/projects/${projectId}/teamcalendar/${event.id}/teamtask`;
+    console.log('onSelectEvent: 팀태스크로 이동', {
+      projectId,
+      planId: event.id,
+      title: event.title,
+      target,
+    });
+    router.push(target);
   };
 
   const handlePrevMonth = () => {
@@ -197,6 +226,7 @@ export default function TeamCalendar() {
               startDate={startDate}
               endDate={endDate}
               setCurrentDate={setCurrentDate}
+              projectCreatedAtISO={projectCreatedAtISO}
             />
           ),
           event: CalendarEventBox, // ✅ 커스텀 일정 카드 디자인

--- a/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
+++ b/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
@@ -9,6 +9,7 @@ import CustomDateCellWrapper from '@/features/teamclendar/CustomDateCellWrapper'
 import axiosInstance from '@/lib/axiosInstance';
 import CalendarEventBox from '@/features/teamclendar/components/CalendarEventBox';
 import { useGetCalendarPlans } from '@/hooks/queries/useGetTeamCalendar';
+import { useGetDashboard } from '@/hooks/queries/useGetDashboard';
 
 const localizer = momentLocalizer(moment);
 
@@ -26,6 +27,7 @@ export default function TeamCalendar() {
   const router = useRouter();
   const params = useParams();
   const projectId = params.projectId?.toString();
+  const projectIdNum = projectId ? Number(projectId) : undefined;
 
   // 현재 보고 있는 달의 첫 날 ~ 마지막 날 계산
   const startDate = useMemo(
@@ -40,6 +42,12 @@ export default function TeamCalendar() {
     isLoading,
     refetch, // ✅ refetch 포함
   } = useGetCalendarPlans(projectId ?? '', startDate, endDate);
+
+  // 대시보드(업무) 데이터도 함께 조회하여 캘린더에 표시
+  const { data: dashboardData } = useGetDashboard({
+    projectId: projectIdNum as number,
+    view: 'status',
+  } as any);
 
   // ✅ 창이 다시 focus될 때 refetch 실행
   useEffect(() => {
@@ -74,7 +82,7 @@ export default function TeamCalendar() {
   }, [projectId]);
 
   // Calendar 표시용 events 가공 (timezone-safe)
-  const events: CalendarEventType[] =
+  const planEvents: CalendarEventType[] =
     calendarData?.result.flatMap((entry) =>
       (entry.list ?? []).flatMap((plan) => {
         const anyPlan = plan as any;
@@ -148,6 +156,37 @@ export default function TeamCalendar() {
         ];
       })
     ) || [];
+
+  // 업무 대시보드 -> 캘린더 이벤트 변환 (마감일 기준, 해당 월 범위만)
+  const dashboardEvents: CalendarEventType[] = useMemo(() => {
+    if (!dashboardData) return [];
+    const startM = moment(startDate);
+    const endM = moment(endDate);
+
+    // statusGroups 또는 steps 중 존재하는 구조에서 tasks를 추출
+    const tasks =
+      'statusGroups' in dashboardData
+        ? (dashboardData.statusGroups || []).flatMap((g: any) => g.tasks || [])
+        : 'steps' in dashboardData
+          ? (dashboardData.steps || []).flatMap((s: any) => s.tasks || [])
+          : [];
+
+    return tasks
+      .filter((t: any) => !!t?.deadline)
+      .map((t: any) => ({
+        id: `task:${String(t.taskId)}`,
+        title: `${t.taskName} 마감`,
+        start: new Date(t.deadline),
+        end: new Date(new Date(t.deadline).getTime() + 60 * 1000),
+        allDay: true,
+      }))
+      .filter((ev: CalendarEventType) => {
+        const m = moment(ev.start);
+        return m.isSameOrAfter(startM, 'day') && m.isSameOrBefore(endM, 'day');
+      });
+  }, [dashboardData, startDate, endDate]);
+
+  const events: CalendarEventType[] = [...planEvents, ...dashboardEvents];
 
   // events 변경 시 콘솔 출력 (일정 자동 반영 확인용)
   useEffect(() => {
@@ -249,16 +288,20 @@ export default function TeamCalendar() {
             </div>
           ), // ✅ 커스텀 일정 카드 디자인 - 클릭 가능 보장
         }}
-        eventPropGetter={() => ({
-          style: {
-            backgroundColor: '#B6F5DF',
-            border: 'none',
-            color: '#000000',
-            borderRadius: '4px',
-            position: 'relative',
-            zIndex: 60,
-          },
-        })}
+        eventPropGetter={(event: any) => {
+          const isTask = typeof event?.id === 'string' && String(event.id).startsWith('task:');
+          const bg = isTask ? '#DAF3F3' : '#B6F5DF';
+          return {
+            style: {
+              backgroundColor: bg,
+              border: 'none',
+              color: '#000000',
+              borderRadius: '4px',
+              position: 'relative',
+              zIndex: 60,
+            },
+          };
+        }}
         popup
         toolbar={false}
       />

--- a/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
+++ b/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
@@ -12,6 +12,14 @@ import { useGetCalendarPlans } from '@/hooks/queries/useGetTeamCalendar';
 
 const localizer = momentLocalizer(moment);
 
+type CalendarEventType = {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+  allDay?: boolean;
+};
+
 export default function TeamCalendar() {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [projectCreatedAtISO, setProjectCreatedAtISO] = useState<string | undefined>(undefined);
@@ -66,10 +74,12 @@ export default function TeamCalendar() {
   }, [projectId]);
 
   // Calendar 표시용 events 가공 (timezone-safe)
-  const events =
+  const events: CalendarEventType[] =
     calendarData?.result.flatMap((entry) =>
-      (entry.list ?? []).map((plan) => {
+      (entry.list ?? []).flatMap((plan) => {
         const anyPlan = plan as any;
+        const rawId = anyPlan?.planId ?? anyPlan?.id ?? anyPlan?.scheduleId;
+        if (!rawId) return [] as CalendarEventType[];
 
         // 1) startDate/endDate가 있으면 그대로 사용
         if (anyPlan.startDate || anyPlan.endDate) {
@@ -77,12 +87,14 @@ export default function TeamCalendar() {
           const end = anyPlan.endDate
             ? new Date(anyPlan.endDate)
             : new Date(new Date(start).getTime() + 60 * 1000);
-          return {
-            id: String(anyPlan.planId),
-            title: anyPlan.name || anyPlan.title || '빈 일정',
-            start,
-            end,
-          };
+          return [
+            {
+              id: String(rawId),
+              title: anyPlan.name || anyPlan.title || '빈 일정',
+              start,
+              end,
+            },
+          ];
         }
 
         // 2) date만 있는 경우: 'YYYY-MM-DD' 또는 'YYYY-MM-DDTHH:mm:ss'
@@ -91,7 +103,6 @@ export default function TeamCalendar() {
         let end: Date;
 
         if (dateStr) {
-          // 안전 파싱: 문자열에서 연-월-일 및 선택적 시:분 추출 후 local Date 생성
           const m = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})(?:[T\s](\d{2}):(\d{2})(?::(\d{2}))?)?/);
           if (m) {
             const year = Number(m[1]);
@@ -110,7 +121,6 @@ export default function TeamCalendar() {
             const second = m[6] ? Number(m[6]) : 0;
             start = new Date(year, monthIdx, day, hour, minute, second);
 
-            // 종료 시간: endHour 우선, 없으면 시작 + 1분
             if (anyPlan.endHour) {
               const [eh, em] = String(anyPlan.endHour).split(':');
               end = new Date(year, monthIdx, day, Number(eh), Number(em) || 0, 0);
@@ -118,24 +128,24 @@ export default function TeamCalendar() {
               end = new Date(start.getTime() + 60 * 1000);
             }
           } else {
-            // 포맷 예측 실패 시 안전 fallback (0분 이벤트 방지: +1분)
             start = new Date();
             end = new Date(start.getTime() + 60 * 1000);
           }
         } else {
-          // date가 전혀 없는 경우
           start = new Date();
           end = new Date(start.getTime() + 60 * 1000);
         }
 
         const isAllDay = !anyPlan.startHour && !anyPlan.endHour;
-        return {
-          id: String(anyPlan.planId),
-          title: anyPlan.name || anyPlan.title || '빈 일정',
-          start,
-          end,
-          ...(isAllDay ? { allDay: true } : {}),
-        };
+        return [
+          {
+            id: String(rawId),
+            title: anyPlan.name || anyPlan.title || '빈 일정',
+            start,
+            end,
+            ...(isAllDay ? { allDay: true } : {}),
+          },
+        ];
       })
     ) || [];
 
@@ -144,7 +154,11 @@ export default function TeamCalendar() {
     console.log('일정 반영 확인:', events);
   }, [events]);
 
-  const handleEventClick = (event: { id: string; title?: string }) => {
+  const handleEventClick = (event: { id?: string; title?: string }) => {
+    if (!event?.id || !projectId) {
+      console.warn('onSelectEvent: 유효하지 않은 이벤트 또는 projectId 누락', { projectId, event });
+      return;
+    }
     const target = `/projects/${projectId}/teamcalendar/${event.id}/teamtask`;
     console.log('onSelectEvent: 팀태스크로 이동', {
       projectId,
@@ -229,7 +243,11 @@ export default function TeamCalendar() {
               projectCreatedAtISO={projectCreatedAtISO}
             />
           ),
-          event: CalendarEventBox, // ✅ 커스텀 일정 카드 디자인
+          event: (props) => (
+            <div className="relative z-[60] pointer-events-auto">
+              <CalendarEventBox {...props} />
+            </div>
+          ), // ✅ 커스텀 일정 카드 디자인 - 클릭 가능 보장
         }}
         eventPropGetter={() => ({
           style: {
@@ -237,6 +255,8 @@ export default function TeamCalendar() {
             border: 'none',
             color: '#000000',
             borderRadius: '4px',
+            position: 'relative',
+            zIndex: 60,
           },
         })}
         popup

--- a/src/features/teamclendar/CustomDateCellWrapper.tsx
+++ b/src/features/teamclendar/CustomDateCellWrapper.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { ReactNode, useState } from 'react';
+import { ReactNode, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import { usePostPlan } from '@/hooks/mutations/usePostTeamCalendar';
+import { usePatchPlan } from '@/hooks/mutations/usePlan';
 import moment from 'moment';
 
 interface CustomDateCellWrapperProps {
@@ -33,6 +34,7 @@ export default function CustomDateCellWrapper({
   const router = useRouter();
   const queryClient = useQueryClient();
   const { mutate } = usePostPlan();
+  const { mutate: patchPlan } = usePatchPlan();
 
   // 오늘 날짜 이후인지 확인 (오늘 포함)
   const isTodayOrAfter = moment(value).isSameOrAfter(moment(), 'day');
@@ -83,6 +85,14 @@ export default function CustomDateCellWrapper({
 
   const hoverActive = hovered && canShowPlusButton;
 
+  // 드래그 앤 드롭: 드래그 진입 시 상단 라인 인디케이터 표시
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [indicatorY, setIndicatorY] = useState<number>(16);
+  const indicatorVisible = isDragOver && canShowPlusButton;
+
+  // 드롭할 목표 날짜 문자열 (로컬 자정)
+  const dropTargetDate = useMemo(() => moment(value).format('YYYY-MM-DD[T]00:00:00'), [value]);
+
   return (
     <div
       className={`relative w-full h-full transition-all duration-200 rounded-[4px] overflow-visible ${hoverActive ? 'shadow-[0_0_10px_rgba(0,0,0,0.25)] cursor-pointer' : ''}`}
@@ -90,8 +100,78 @@ export default function CustomDateCellWrapper({
         if (canShowPlusButton) setHovered(true);
       }}
       onMouseLeave={() => setHovered(false)}
+      onDragEnter={(e) => {
+        // 외부에서 넘어온 일정만 허용
+        const hasData =
+          e.dataTransfer.types.includes('application/x-teamie-plan') ||
+          e.dataTransfer.types.includes('text/plain');
+        if (hasData && canShowPlusButton) {
+          const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
+          const y = Math.max(8, Math.min(e.clientY - rect.top, rect.height - 8));
+          setIndicatorY(y);
+          setIsDragOver(true);
+        }
+      }}
+      onDragOver={(e) => {
+        const hasData =
+          e.dataTransfer.types.includes('application/x-teamie-plan') ||
+          e.dataTransfer.types.includes('text/plain');
+        if (hasData && canShowPlusButton) {
+          e.preventDefault();
+          e.dataTransfer.dropEffect = 'move';
+          const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
+          const y = Math.max(8, Math.min(e.clientY - rect.top, rect.height - 8));
+          setIndicatorY(y);
+          setIsDragOver(true);
+        }
+      }}
+      onDragLeave={() => setIsDragOver(false)}
+      onDrop={(e) => {
+        e.preventDefault();
+        setIsDragOver(false);
+        if (!canShowPlusButton) return;
+        try {
+          const raw =
+            e.dataTransfer.getData('application/x-teamie-plan') ||
+            e.dataTransfer.getData('text/plain');
+          const parsed = raw ? JSON.parse(raw) : null;
+          const planId: string | undefined = parsed?.planId;
+          if (!planId) return;
+
+          // 일정 날짜만 변경
+          patchPlan(
+            { planId, planData: { date: dropTargetDate } },
+            {
+              onSuccess: () => {
+                // 현재 월 범위 일정 목록 새로고침
+                if (projectId) {
+                  queryClient.invalidateQueries({
+                    queryKey: ['calendarPlans', projectId, startDate, endDate],
+                  });
+                }
+              },
+            }
+          );
+        } catch {
+          // 파싱 실패 시 무시
+        }
+      }}
     >
       {children}
+      {/* 드래그 오버 라인 인디케이터 */}
+      {indicatorVisible && (
+        <div
+          className="pointer-events-none absolute left-1/2 -translate-x-1/2"
+          style={{
+            top: indicatorY,
+            width: '196px',
+            height: '3px',
+            borderRadius: '10px',
+            backgroundColor: '#81D7D4',
+            boxShadow: '0 0 4px #81D7D4',
+          }}
+        />
+      )}
       {/* 플러스 버튼 - 가벼운 호버 센서 사용: 캘린더 이벤트 클릭을 막지 않음 */}
       {canShowPlusButton && (
         <div className="absolute top-0 right-0 z-[70] w-[40px] h-[40px] pointer-events-auto">

--- a/src/features/teamclendar/CustomDateCellWrapper.tsx
+++ b/src/features/teamclendar/CustomDateCellWrapper.tsx
@@ -15,6 +15,7 @@ interface CustomDateCellWrapperProps {
   currentDate?: Date;
   setCurrentDate: (date: Date) => void;
   latestPlanDate?: string; // 가장 최근 일정 날짜 추가
+  projectCreatedAtISO?: string; // 프로젝트 생성일 (이전 날짜에는 추가/호버 비활성화)
 }
 
 export default function CustomDateCellWrapper({
@@ -26,6 +27,7 @@ export default function CustomDateCellWrapper({
   setCurrentDate,
   currentDate = new Date(),
   latestPlanDate,
+  projectCreatedAtISO,
 }: CustomDateCellWrapperProps) {
   const [hovered, setHovered] = useState(false);
   const router = useRouter();
@@ -35,8 +37,13 @@ export default function CustomDateCellWrapper({
   // 오늘 날짜 이후인지 확인 (오늘 포함)
   const isTodayOrAfter = moment(value).isSameOrAfter(moment(), 'day');
 
-  // 플러스 버튼을 표시할 수 있는지 확인 (모든 날짜에서 오늘 이후만)
-  const canShowPlusButton = isTodayOrAfter;
+  // 프로젝트 생성일 이전인지 확인
+  const isBeforeProjectCreation = projectCreatedAtISO
+    ? moment(value).isBefore(moment(projectCreatedAtISO), 'day')
+    : false;
+
+  // 플러스 버튼 표시 조건: 오늘 이후이면서, 프로젝트 생성일 이후만
+  const canShowPlusButton = isTodayOrAfter && !isBeforeProjectCreation;
 
   const handleClick = () => {
     if (!projectId || !canShowPlusButton) return;
@@ -74,29 +81,17 @@ export default function CustomDateCellWrapper({
     );
   };
 
+  const hoverActive = hovered && canShowPlusButton;
+
   return (
     <div
-      className={`relative w-full h-full transition-all duration-200 rounded-[4px] z-[10] overflow-visible ${hovered ? 'shadow-[0_0_10px_rgba(0,0,0,0.25)] cursor-pointer' : ''}`}
-      onMouseEnter={() => setHovered(true)}
+      className={`relative w-full h-full transition-all duration-200 rounded-[4px] z-[50] overflow-visible ${hoverActive ? 'shadow-[0_0_10px_rgba(0,0,0,0.25)] cursor-pointer' : ''}`}
+      onMouseEnter={() => {
+        if (canShowPlusButton) setHovered(true);
+      }}
       onMouseLeave={() => setHovered(false)}
     >
       {children}
-
-      {/* 플러스 버튼 */}
-      <div
-        className="absolute top-[8px] right-[8px] z-[60]"
-        onMouseEnter={() => setHovered(true)}
-        onMouseLeave={() => setHovered(false)}
-      >
-        {hovered && (
-          <button
-            className="flex items-center justify-center rounded-[4px] cursor-pointer"
-            onClick={handleClick}
-          >
-            <img src="/icons/AddProject.svg" alt="일정 추가" className="w-[24px] h-[24px]" />
-          </button>
-        )}
-      </div>
       {/* 플러스 버튼 - 현재 달의 날짜이면서 최근 일정 이후 날짜에서만 표시 */}
       {canShowPlusButton && (
         <div

--- a/src/features/teamclendar/CustomDateCellWrapper.tsx
+++ b/src/features/teamclendar/CustomDateCellWrapper.tsx
@@ -85,28 +85,30 @@ export default function CustomDateCellWrapper({
 
   return (
     <div
-      className={`relative w-full h-full transition-all duration-200 rounded-[4px] z-[50] overflow-visible ${hoverActive ? 'shadow-[0_0_10px_rgba(0,0,0,0.25)] cursor-pointer' : ''}`}
+      className={`relative w-full h-full transition-all duration-200 rounded-[4px] overflow-visible ${hoverActive ? 'shadow-[0_0_10px_rgba(0,0,0,0.25)] cursor-pointer' : ''}`}
       onMouseEnter={() => {
         if (canShowPlusButton) setHovered(true);
       }}
       onMouseLeave={() => setHovered(false)}
     >
       {children}
-      {/* 플러스 버튼 - 현재 달의 날짜이면서 최근 일정 이후 날짜에서만 표시 */}
+      {/* 플러스 버튼 - 가벼운 호버 센서 사용: 캘린더 이벤트 클릭을 막지 않음 */}
       {canShowPlusButton && (
-        <div
-          className="absolute top-[8px] right-[8px]"
-          onMouseEnter={() => setHovered(true)}
-          onMouseLeave={() => setHovered(false)}
-        >
-          {hovered && (
-            <button
-              className="flex items-center justify-center rounded-[4px] cursor-pointer"
-              onClick={handleClick}
-            >
-              <img src="/icons/AddProject.svg" alt="일정 추가" className="w-[24px] h-[24px]" />
-            </button>
-          )}
+        <div className="absolute top-0 right-0 z-[70] w-[40px] h-[40px] pointer-events-auto">
+          <div
+            className="absolute top-[8px] right-[8px]"
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+          >
+            {hovered && (
+              <button
+                className="flex items-center justify-center rounded-[4px] cursor-pointer"
+                onClick={handleClick}
+              >
+                <img src="/icons/AddProject.svg" alt="일정 추가" className="w-[24px] h-[24px]" />
+              </button>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/src/features/teamclendar/CustomDateCellWrapper.tsx
+++ b/src/features/teamclendar/CustomDateCellWrapper.tsx
@@ -87,7 +87,7 @@ export default function CustomDateCellWrapper({
 
   // 드래그 앤 드롭: 드래그 진입 시 상단 라인 인디케이터 표시
   const [isDragOver, setIsDragOver] = useState(false);
-  const [indicatorY, setIndicatorY] = useState<number>(16);
+  const [indicatorY, setIndicatorY] = useState<number>(4);
   const indicatorVisible = isDragOver && canShowPlusButton;
 
   // 드롭할 목표 날짜 문자열 (로컬 자정)
@@ -164,7 +164,7 @@ export default function CustomDateCellWrapper({
           className="pointer-events-none absolute left-1/2 -translate-x-1/2"
           style={{
             top: indicatorY,
-            width: '196px',
+            width: '100%',
             height: '3px',
             borderRadius: '10px',
             backgroundColor: '#81D7D4',

--- a/src/features/teamclendar/components/CalendarEventBox.tsx
+++ b/src/features/teamclendar/components/CalendarEventBox.tsx
@@ -12,6 +12,15 @@ export default function CalendarEventBox({ event }: { event: CalendarEvent }) {
   const params = useParams();
   const projectId = params.projectId?.toString();
 
+  const handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
+    if (event?.id == null) return;
+    // 커스텀 MIME 타입과 텍스트 둘 다 넣어 브라우저/플랫폼 호환성 확보
+    const payload = JSON.stringify({ planId: String(event.id) });
+    e.dataTransfer.setData('application/x-teamie-plan', payload);
+    e.dataTransfer.setData('text/plain', payload);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
     if (!projectId || event?.id == null) return;
@@ -27,6 +36,8 @@ export default function CalendarEventBox({ event }: { event: CalendarEvent }) {
 
   return (
     <div
+      draggable
+      onDragStart={handleDragStart}
       onClick={handleClick}
       className="relative z-[60] w-full h-full rounded-[4px] px-[22px] py-[4px] text-[16px] leading-[24px] text-black overflow-hidden whitespace-nowrap text-ellipsis flex items-center justify-center cursor-pointer pointer-events-auto"
       title={event.title ?? ''}

--- a/src/features/teamclendar/components/CalendarEventBox.tsx
+++ b/src/features/teamclendar/components/CalendarEventBox.tsx
@@ -11,9 +11,11 @@ export default function CalendarEventBox({ event }: { event: CalendarEvent }) {
   const router = useRouter();
   const params = useParams();
   const projectId = params.projectId?.toString();
+  const isTask = typeof event?.id === 'string' && String(event.id).startsWith('task:');
+  const taskId = isTask ? String(event.id).replace('task:', '') : undefined;
 
   const handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
-    if (event?.id == null) return;
+    if (event?.id == null || isTask) return; // 업무 카드는 드래그 금지
     // 커스텀 MIME 타입과 텍스트 둘 다 넣어 브라우저/플랫폼 호환성 확보
     const payload = JSON.stringify({ planId: String(event.id) });
     e.dataTransfer.setData('application/x-teamie-plan', payload);
@@ -24,10 +26,12 @@ export default function CalendarEventBox({ event }: { event: CalendarEvent }) {
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
     if (!projectId || event?.id == null) return;
-    const target = `/projects/${projectId}/teamcalendar/${String(event.id)}/teamtask`;
+    const target = isTask
+      ? `/projects/${projectId}/tasks/${taskId}`
+      : `/projects/${projectId}/teamcalendar/${String(event.id)}/teamtask`;
     console.log('이벤트 클릭: 팀태스크로 이동', {
       projectId,
-      planId: String(event.id),
+      id: String(event.id),
       title: event.title,
       target,
     });
@@ -36,7 +40,7 @@ export default function CalendarEventBox({ event }: { event: CalendarEvent }) {
 
   return (
     <div
-      draggable
+      draggable={!isTask}
       onDragStart={handleDragStart}
       onClick={handleClick}
       className="relative z-[60] w-full h-full rounded-[4px] px-[22px] py-[4px] text-[16px] leading-[24px] text-black overflow-hidden whitespace-nowrap text-ellipsis flex items-center justify-center cursor-pointer pointer-events-auto"

--- a/src/features/teamclendar/components/CalendarEventBox.tsx
+++ b/src/features/teamclendar/components/CalendarEventBox.tsx
@@ -1,6 +1,37 @@
-export default function CalendarEventBox({ event }: { event: { title?: string } }) {
+'use client';
+
+import { useParams, useRouter } from 'next/navigation';
+
+type CalendarEvent = {
+  id?: string | number;
+  title?: string;
+};
+
+export default function CalendarEventBox({ event }: { event: CalendarEvent }) {
+  const router = useRouter();
+  const params = useParams();
+  const projectId = params.projectId?.toString();
+
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    if (!projectId || event?.id == null) return;
+    const target = `/projects/${projectId}/teamcalendar/${String(event.id)}/teamtask`;
+    console.log('이벤트 클릭: 팀태스크로 이동', {
+      projectId,
+      planId: String(event.id),
+      title: event.title,
+      target,
+    });
+    router.push(target);
+  };
+
   return (
-    <div className=" w-full h-full rounded-[4px] px-[22px] py-[4px] text-[16px] leading-[24px] text-black overflow-hidden whitespace-nowrap text-ellipsis flex items-center justify-center">
+    <div
+      onClick={handleClick}
+      className=" z-[60] w-full h-full rounded-[4px] px-[22px] py-[4px] text-[16px] leading-[24px] text-black overflow-hidden whitespace-nowrap text-ellipsis flex items-center justify-center cursor-pointer"
+      title={event.title ?? ''}
+      role="button"
+    >
       {event.title || '빈 일정'}
     </div>
   );

--- a/src/features/teamclendar/components/CalendarEventBox.tsx
+++ b/src/features/teamclendar/components/CalendarEventBox.tsx
@@ -28,7 +28,7 @@ export default function CalendarEventBox({ event }: { event: CalendarEvent }) {
   return (
     <div
       onClick={handleClick}
-      className=" z-[60] w-full h-full rounded-[4px] px-[22px] py-[4px] text-[16px] leading-[24px] text-black overflow-hidden whitespace-nowrap text-ellipsis flex items-center justify-center cursor-pointer"
+      className="relative z-[60] w-full h-full rounded-[4px] px-[22px] py-[4px] text-[16px] leading-[24px] text-black overflow-hidden whitespace-nowrap text-ellipsis flex items-center justify-center cursor-pointer pointer-events-auto"
       title={event.title ?? ''}
       role="button"
     >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,6 +1,5 @@
 @import 'tailwindcss';
 
-
 /* 요일 헤더 간 눈금선 제거 */
 .rbc-month-view .rbc-month-header .rbc-header:last-child {
   border-right: none !important;
@@ -10,7 +9,6 @@
 .rbc-month-header {
   border-bottom: 2px solid #bbbbbb !important; /* gray-300 */
 }
-
 
 .rbc-month-row .rbc-date-cell {
   border-left: none !important;
@@ -37,15 +35,15 @@
   border: none !important;
   box-shadow: none !important;
   overflow: visible !important; /*가장 자리 호버 추가*/
-} 
+}
 
 /* 각 주간(week row)마다 가로줄 구분선 추가 */
 .rbc-month-row {
-  border-bottom: 2px solid #BBBBBB !important;
+  border-bottom: 2px solid #bbbbbb !important;
 }
 
-.rbc-header  {
-  border-bottom: 2px solid #BBBBBB !important;
+.rbc-header {
+  border-bottom: 2px solid #bbbbbb !important;
 }
 
 /* 날짜 숫자 왼쪽 정렬 */
@@ -59,7 +57,7 @@
   text-align: left !important;
   padding-left: 13px !important;
   padding-top: 12px !important;
-  font-weight: 500; 
+  font-weight: 500;
 }
 
 /* 누락된 항목 (추가해야 함) */
@@ -76,18 +74,18 @@
   color: #000000 !important;
   text-align: center;
   text-transform: uppercase !important;
-  padding-bottom: 20px !important; 
+  padding-bottom: 20px !important;
 }
 
 /* 일요일만 빨간색 */
 .rbc-month-header .rbc-header:first-child {
-  color: #D81B1B !important;
+  color: #d81b1b !important;
 }
 
 /* 오늘 날짜 표시하는 거 제거 */
 .rbc-day-bg.rbc-today {
   background-color: transparent !important;
-} 
+}
 
 /* 이벤트가 많은 날도 자동 높이 확장 허용 */
 .rbc-month-row {
@@ -100,5 +98,11 @@
   overflow: visible !important;
   text-overflow: unset !important;
   display: block !important;
-  word-break: keep-all !important;  
+  word-break: keep-all !important;
+}
+
+/* 드래그 라인 인디케이터 대비용: 캘린더 셀은 overflow visible */
+.rbc-day-bg,
+.rbc-date-cell {
+  overflow: visible !important;
 }


### PR DESCRIPTION
## 연관 이슈
- Closes #157 

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
1. 드래그 앤 드롭 반영
2. 프로젝트 생성 날짜 이전 플러스 버튼/ 호버 불가(일정 생성 불가)
3. 업무 카드 클릭시 해당 상세 페이지 이동
4. 업무 대시 보드 내용 반영

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-
