### PR TITLE
[Fix/189] 복사 모달 유지 시간

### DIFF
--- a/src/components/CopyModal.tsx
+++ b/src/components/CopyModal.tsx
@@ -43,7 +43,7 @@ const CopyModal = ({
           <Image src="/icons/close.svg" alt="close" width={24} height={24} />
         </button>
         <div className="mb-[1.5rem]">
-          <h1 className="text-[1.25rem] font-semibold text-black leading-relaxed">
+          <h1 className="text-[1.25rem] font-semibold text-black leading-[28px]">
             {headerText.split('<br>').map((line, index) => (
               <span key={index}>
                 {line}
@@ -60,13 +60,13 @@ const CopyModal = ({
             onClick={handleCopy}
             className="absolute top-[0.75rem] right-[0.75rem] cursor-pointer"
           >
-            <Image src="/icons/copy_url.svg" alt="copy_url" width={24} height={24} />
+            <Image src="/icons/copy_url.svg" alt="copy_url" width={15} height={18} />
           </button>
           <div className="text-center text-[1rem] text-black">{messageContent}</div>
         </div>
         {isCopied && (
           <div className="absolute bottom-[1.25rem] left-1/2 transform -translate-x-1/2 z-50">
-            <div className="bg-[#F8F8F8] text-[#505050] px-[1.25rem] py-[0.5rem] border-[0.09375rem] border-[#BBBBBB] rounded-[0.375rem] text-[0.875rem] whitespace-nowrap">
+            <div className="bg-[#F8F8F8] text-[#505050] leading-[22px] px-[1.25rem] py-[6px] border-[0.09375rem] border-[#BBBBBB] rounded-[0.375rem] text-[0.875rem] whitespace-nowrap">
               {copySuccessText}
             </div>
           </div>

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -4,11 +4,13 @@ import { useTaskItems } from '@/features/boards/hooks/useTaskItems';
 import { TaskItemComponentProps, TASK_STATUS_STYLES } from '@/types/api/tasks';
 import { useUpdateTaskStatus } from '@/hooks/mutations/useUpdateTaskStatus';
 import Link from 'next/link';
-import { useState } from 'react';
-import CopyModal from './CopyModal';
-import Portal from './Portal';
 import AssigneeCard from './AssigneeCard';
 import { formatToKoreanDate } from '@/utils/formatDate';
+
+// TaskItem 컴포넌트 Props에 onTaskComplete 콜백 추가
+interface TaskItemProps extends TaskItemComponentProps {
+  onTaskComplete?: (taskId: number, title: string) => void;
+}
 
 export default function TaskItem({
   projectId,
@@ -17,11 +19,11 @@ export default function TaskItem({
   status,
   deadline,
   assignee,
-}: TaskItemComponentProps) {
+  onTaskComplete,
+}: TaskItemProps) {
   const { displayAssignees, deadlineTextColor } = useTaskItems({
     task: { id: taskId, title, status, deadline, assignee },
   });
-  const [showCopyModal, setShowCopyModal] = useState(false);
 
   const updateTaskStatusMutation = useUpdateTaskStatus();
 
@@ -48,120 +50,84 @@ export default function TaskItem({
       status: newStatus,
     });
 
-    if (newStatus === 'COMPLETED') {
-      setShowCopyModal(true);
+    // 완료 상태로 변경된 경우 부모 컴포넌트에 알림
+    if (newStatus === 'COMPLETED' && onTaskComplete) {
+      onTaskComplete(taskId, title);
     }
   };
 
   // 체크박스 상태 결정 (완료 상태일 때만 체크됨)
   const isChecked = status === '완료';
 
-  // 복사될 링크 URL
-  const taskUrl = `http://localhost:3000/projects/${projectId}/tasks/${taskId}`;
-
-  // 클립보드에 복사될 순수 텍스트
-  const textToCopy = `💼 ${title} 업무가 완료되었어요!\n확인 후 간단한 피드백을 남겨주세요.\n👉 ${taskUrl}`;
-
   return (
-    <>
-      <Link href={`/projects/${projectId}/tasks/${taskId}`} className="block w-[325px]">
-        <div className="bg-white w-full h-full rounded-[8px] border border-[#BBBBBB] p-4 flex items-start gap-3">
-          <label
-            className="relative inline-flex items-center flex-shrink-0 mt-1"
+    <Link href={`/projects/${projectId}/tasks/${taskId}`} className="block w-[325px]">
+      <div className="bg-white w-full h-full rounded-[8px] border border-[#BBBBBB] p-4 flex items-start gap-3">
+        <label
+          className="relative inline-flex items-center flex-shrink-0 mt-1"
+          onClick={stop}
+          onMouseDown={stop}
+          onTouchStart={stop}
+        >
+          <input
+            type="checkbox"
+            checked={isChecked}
+            onChange={handleCheckboxChange}
+            className="peer appearance-none w-[20px] h-[20px] border-2 border-[#898989] rounded bg-white cursor-pointer checked:bg-[#81D7D4]"
             onClick={stop}
             onMouseDown={stop}
             onTouchStart={stop}
-          >
-            <input
-              type="checkbox"
-              checked={isChecked}
-              onChange={handleCheckboxChange}
-              className="peer appearance-none w-[20px] h-[20px] border-2 border-[#898989] rounded bg-white cursor-pointer checked:bg-[#81D7D4]"
-              onClick={stop}
-              onMouseDown={stop}
-              onTouchStart={stop}
-            />
-            <svg
-              className="hidden peer-checked:block absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none"
-              width="13"
-              height="12"
-              viewBox="0 0 13 12"
-              fill="white"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M4.8383 12C4.41459 12 4.0133 11.826 3.75615 11.526L0.275947 7.47901C0.168101 7.35411 0.0893379 7.21171 0.0441773 7.05996C-0.00098324 6.90821 -0.0116524 6.7501 0.0127817 6.59472C0.0372158 6.43933 0.0962722 6.28972 0.186563 6.15447C0.276853 6.01922 0.396601 5.90099 0.538935 5.80656C0.680907 5.71139 0.842861 5.64185 1.01548 5.60195C1.1881 5.56206 1.36798 5.5526 1.54477 5.57411C1.72156 5.59562 1.89177 5.64768 2.04562 5.72729C2.19947 5.80691 2.33391 5.91251 2.44121 6.03802L4.73115 8.69884L10.4886 0.562076C10.6796 0.293422 10.9838 0.102387 11.3346 0.0308751C11.6853 -0.040637 12.054 0.0132126 12.3597 0.180612C12.9958 0.528644 13.1916 1.26586 12.7942 1.82648L5.99155 11.4359C5.87542 11.6007 5.71536 11.7381 5.52525 11.8361C5.33515 11.9341 5.12074 11.9897 4.90063 11.9983L4.8383 12Z"
-                fill="white"
-              />
-            </svg>
-          </label>
-
-          <div className="flex flex-col flex-1 gap-[10px]">
-            <div className="font-normal text-[16px] text-black mt-[1px]">{title}</div>
-
-            <div className="flex items-center justify-between gap-[2px] text-[14px]">
-              <span className="min-w-[7.5rem]">
-                {deadline && (
-                  <span className={deadlineTextColor}>{formatToKoreanDate(deadline)}</span>
-                )}
-              </span>
-
-              <div
-                className={`flex items-center justify-center px-2 py-0.5 w-[63px] h-[22px] rounded-full font-regular ${statusStyle.bg} ${statusStyle.text}`}
-              >
-                {status}
-              </div>
-            </div>
-
-            {displayAssignees && (
-              <div className="mt-auto flex flex-wrap gap-2">
-                {displayAssignees.displayList.map((assignee, index) => (
-                  <AssigneeCard
-                    key={index}
-                    name={assignee.name}
-                    imageUrl={assignee.imageUrl}
-                    size="sm"
-                  />
-                ))}
-                {displayAssignees.hasMore && (
-                  <div className="inline-flex items-center rounded-[30px] p-[3px] pr-[9px] text-[12px] text-[#898989]">
-                    ...
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-        </div>
-      </Link>
-      {showCopyModal && (
-        <Portal>
-          <CopyModal
-            isOpen={showCopyModal}
-            onClose={() => setShowCopyModal(false)}
-            headerText="업무가 완료되었습니다.<br>피드백 요청을 위한 메세지를 복사하여<br>팀원들에게 전달하세요."
-            messageContent={
-              <>
-                💼 {title} 업무가 완료되었어요!
-                <br />
-                확인 후 간단한 피드백을 남겨주세요.
-                <br />
-                👉{' '}
-                <Link
-                  href={taskUrl}
-                  className="underline font-bold text-[#81D7D4]"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {title}
-                </Link>
-              </>
-            }
-            textToCopy={textToCopy}
-            copySuccessText="업무 완료 메세지가 복사되었습니다."
-            innerPaddingX="5rem"
           />
-        </Portal>
-      )}
-    </>
+          <svg
+            className="hidden peer-checked:block absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none"
+            width="13"
+            height="12"
+            viewBox="0 0 13 12"
+            fill="white"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M4.8383 12C4.41459 12 4.0133 11.826 3.75615 11.526L0.275947 7.47901C0.168101 7.35411 0.0893379 7.21171 0.0441773 7.05996C-0.00098324 6.90821 -0.0116524 6.7501 0.0127817 6.59472C0.0372158 6.43933 0.0962722 6.28972 0.186563 6.15447C0.276853 6.01922 0.396601 5.90099 0.538935 5.80656C0.680907 5.71139 0.842861 5.64185 1.01548 5.60195C1.1881 5.56206 1.36798 5.5526 1.54477 5.57411C1.72156 5.59562 1.89177 5.64768 2.04562 5.72729C2.19947 5.80691 2.33391 5.91251 2.44121 6.03802L4.73115 8.69884L10.4886 0.562076C10.6796 0.293422 10.9838 0.102387 11.3346 0.0308751C11.6853 -0.040637 12.054 0.0132126 12.3597 0.180612C12.9958 0.528644 13.1916 1.26586 12.7942 1.82648L5.99155 11.4359C5.87542 11.6007 5.71536 11.7381 5.52525 11.8361C5.33515 11.9341 5.12074 11.9897 4.90063 11.9983L4.8383 12Z"
+              fill="white"
+            />
+          </svg>
+        </label>
+
+        <div className="flex flex-col flex-1 gap-[10px]">
+          <div className="font-normal text-[16px] text-black mt-[1px]">{title}</div>
+
+          <div className="flex items-center justify-between gap-[2px] text-[14px]">
+            <span className="min-w-[7.5rem]">
+              {deadline && (
+                <span className={deadlineTextColor}>{formatToKoreanDate(deadline)}</span>
+              )}
+            </span>
+
+            <div
+              className={`flex items-center justify-center px-2 py-0.5 w-[63px] h-[22px] rounded-full font-regular ${statusStyle.bg} ${statusStyle.text}`}
+            >
+              {status}
+            </div>
+          </div>
+
+          {displayAssignees && (
+            <div className="mt-auto flex flex-wrap gap-2">
+              {displayAssignees.displayList.map((assignee, index) => (
+                <AssigneeCard
+                  key={index}
+                  name={assignee.name}
+                  imageUrl={assignee.imageUrl}
+                  size="sm"
+                />
+              ))}
+              {displayAssignees.hasMore && (
+                <div className="inline-flex items-center rounded-[30px] p-[3px] pr-[9px] text-[12px] text-[#898989]">
+                  ...
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </Link>
   );
 }

--- a/src/features/boards/MyTaskBoard.tsx
+++ b/src/features/boards/MyTaskBoard.tsx
@@ -2,6 +2,9 @@ import { useEffect, useState, useMemo } from 'react';
 import TaskItem from '@/components/TaskItem';
 import ProjectHeader from './components/ProjectHeader';
 import { useGetMyTasks } from '@/hooks/queries/useGetMyTasks';
+import CopyModal from '@/components/CopyModal';
+import Portal from '@/components/Portal';
+import Link from 'next/link';
 
 export default function MyTaskBoard() {
   const { data, isLoading } = useGetMyTasks();
@@ -12,6 +15,12 @@ export default function MyTaskBoard() {
   }, [data?.result?.data]);
 
   const [openProjectIds, setOpenProjectIds] = useState<string[]>([]);
+  const [showCopyModal, setShowCopyModal] = useState(false);
+  const [completedTask, setCompletedTask] = useState<{
+    title: string;
+    taskId: number;
+    projectId: string;
+  } | null>(null);
 
   useEffect(() => {
     if (projects.length > 0) {
@@ -37,42 +46,102 @@ export default function MyTaskBoard() {
     }
   };
 
+  // 업무 완료 시 호출되는 콜백 함수
+  const handleTaskComplete = (taskId: number, title: string, projectId: string) => {
+    setCompletedTask({ taskId, title, projectId });
+    setShowCopyModal(true);
+  };
+
+  // 모달 닫기 핸들러
+  const handleCloseModal = () => {
+    setShowCopyModal(false);
+    setCompletedTask(null);
+  };
+
+  // 복사될 링크 URL
+  const getTaskUrl = (taskId: number, projectId: string) =>
+    `http://localhost:3000/projects/${projectId}/tasks/${taskId}`;
+
+  // 클립보드에 복사될 순수 텍스트
+  const getTextToCopy = (title: string, taskId: number, projectId: string) =>
+    `💼 ${title} 업무가 완료되었어요!\n확인 후 간단한 피드백을 남겨주세요.\n👉 ${getTaskUrl(taskId, projectId)}`;
+
   if (isLoading) {
     return <div className="mt-10 text-center">불러오는 중...</div>;
   }
 
   return (
-    <div
-      className="grid [grid-template-columns:repeat(2,20.313rem)] lg:[grid-template-columns:repeat(4,20.313rem)] gap-x-[2.25rem] gap-y-[5rem] mt-[3.75rem] min-w-[64rem] overflow-x-auto"
-      style={{ paddingLeft: 'clamp(43px, calc(112px - ((100vw - 1024px) * 0.077)), 112px)' }}
-    >
-      {projects.map((project) => (
-        <div key={project.projectId}>
-          <ProjectHeader
-            projectName={project.projectName}
-            isOpen={openProjectIds.includes(String(project.projectId))}
-            onToggle={() => handleToggle(String(project.projectId))}
+    <>
+      <div
+        className="grid [grid-template-columns:repeat(2,20.313rem)] lg:[grid-template-columns:repeat(4,20.313rem)] gap-x-[2.25rem] gap-y-[5rem] mt-[3.75rem] min-w-[64rem] overflow-x-auto"
+        style={{ paddingLeft: 'clamp(43px, calc(112px - ((100vw - 1024px) * 0.077)), 112px)' }}
+      >
+        {projects.map((project) => (
+          <div key={project.projectId}>
+            <ProjectHeader
+              projectName={project.projectName}
+              isOpen={openProjectIds.includes(String(project.projectId))}
+              onToggle={() => handleToggle(String(project.projectId))}
+            />
+            {openProjectIds.includes(String(project.projectId)) && (
+              <div className="flex flex-col gap-3 mt-[1.5rem]">
+                {project.tasks.map((task) => (
+                  <TaskItem
+                    key={task.id}
+                    projectId={String(project.projectId)}
+                    id={task.id}
+                    title={task.name}
+                    status={mapStatus(task.status)}
+                    deadline={task.deadline}
+                    assignee={task.managers.map((m) => ({
+                      name: m.name,
+                      imageUrl: m.imageUrl,
+                    }))}
+                    onTaskComplete={(taskId, title) =>
+                      handleTaskComplete(taskId, title, String(project.projectId))
+                    }
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* CopyModal */}
+      {showCopyModal && completedTask && (
+        <Portal>
+          <CopyModal
+            isOpen={showCopyModal}
+            onClose={handleCloseModal}
+            headerText="업무가 완료되었습니다.<br>피드백 요청을 위한 메세지를 복사하여<br>팀원들에게 전달하세요."
+            messageContent={
+              <>
+                💼 {completedTask.title} 업무가 완료되었어요!
+                <br />
+                확인 후 간단한 피드백을 남겨주세요.
+                <br />
+                👉{' '}
+                <Link
+                  href={getTaskUrl(completedTask.taskId, completedTask.projectId)}
+                  className="underline font-bold text-[#81D7D4]"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {completedTask.title}
+                </Link>
+              </>
+            }
+            textToCopy={getTextToCopy(
+              completedTask.title,
+              completedTask.taskId,
+              completedTask.projectId
+            )}
+            copySuccessText="업무 완료 메세지가 복사되었습니다."
+            innerPaddingX="5rem"
           />
-          {openProjectIds.includes(String(project.projectId)) && (
-            <div className="flex flex-col gap-3 mt-[1.5rem]">
-              {project.tasks.map((task) => (
-                <TaskItem
-                  key={task.id}
-                  projectId={String(project.projectId)}
-                  id={task.id}
-                  title={task.name}
-                  status={mapStatus(task.status)}
-                  deadline={task.deadline}
-                  assignee={task.managers.map((m) => ({
-                    name: m.name,
-                    imageUrl: m.imageUrl,
-                  }))}
-                />
-              ))}
-            </div>
-          )}
-        </div>
-      ))}
-    </div>
+        </Portal>
+      )}
+    </>
   );
 }

--- a/src/features/boards/StatusBoard.tsx
+++ b/src/features/boards/StatusBoard.tsx
@@ -158,7 +158,7 @@ export default function StatusBoard({ statusGroups, projectId }: StatusBoardProp
                           >
                             <div {...provided.dragHandleProps}>
                               <TaskItem
-                                projectId={projectId}
+                                projectId={String(projectId)}
                                 id={task.taskId}
                                 title={task.taskName}
                                 status={task.displayStatus}
@@ -167,6 +167,11 @@ export default function StatusBoard({ statusGroups, projectId }: StatusBoardProp
                                   name: manager.name,
                                   imageUrl: manager.imageUrl,
                                 }))}
+                                onTaskComplete={(taskId, title) => {
+                                  // 완료 상태로 변경된 경우 모달 표시
+                                  setCompletedTask({ title, taskId });
+                                  setShowCopyModal(true);
+                                }}
                               />
                             </div>
                           </div>

--- a/src/features/boards/StepsBoard.tsx
+++ b/src/features/boards/StepsBoard.tsx
@@ -9,6 +9,10 @@ import AddTaskButton from './components/AddTaskButton';
 import StepHeader from './components/StepHeader';
 import TaskItem from '@/components/TaskItem';
 import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
+import { useState } from 'react';
+import CopyModal from '@/components/CopyModal';
+import Portal from '@/components/Portal';
+import Link from 'next/link';
 
 export default function StepsBoard({ steps, projectId }: StepsBoardProps) {
   const { openStepIds, toggleStep, openStep } = useSteps();
@@ -16,6 +20,13 @@ export default function StepsBoard({ steps, projectId }: StepsBoardProps) {
   const deleteStepMutation = useDeleteStep();
   const updateStepMutation = useUpdateStep();
   const updateTaskStepMutation = useUpdateTaskStep();
+
+  // 모달 상태 관리
+  const [showCopyModal, setShowCopyModal] = useState(false);
+  const [completedTask, setCompletedTask] = useState<{ title: string; taskId: number } | null>(
+    null
+  );
+
   // STEP 추가 제한 (최대 8개)
   const canAddStep = steps.length < 8;
 
@@ -30,6 +41,26 @@ export default function StepsBoard({ steps, projectId }: StepsBoardProps) {
         return TASK_STATUS_DISPLAY.NOTSTART;
     }
   };
+
+  // 업무 완료 시 호출되는 콜백 함수
+  const handleTaskComplete = (taskId: number, title: string) => {
+    setCompletedTask({ taskId, title });
+    setShowCopyModal(true);
+  };
+
+  // 모달 닫기 핸들러
+  const handleCloseModal = () => {
+    setShowCopyModal(false);
+    setCompletedTask(null);
+  };
+
+  // 복사될 링크 URL
+  const getTaskUrl = (taskId: number) =>
+    `http://localhost:3000/projects/${projectId}/tasks/${taskId}`;
+
+  // 클립보드에 복사될 순수 텍스트
+  const getTextToCopy = (title: string, taskId: number) =>
+    `💼 ${title} 업무가 완료되었어요!\n확인 후 간단한 피드백을 남겨주세요.\n👉 ${getTaskUrl(taskId)}`;
 
   // STEP 추가 처리
   const handleAddStep = async () => {
@@ -120,92 +151,126 @@ export default function StepsBoard({ steps, projectId }: StepsBoardProps) {
   };
 
   return (
-    <DragDropContext onDragEnd={onDragEnd}>
-      <div
-        className="grid [grid-template-columns:repeat(2,20.313rem)] lg:[grid-template-columns:repeat(4,20.313rem)] gap-x-[2.25rem] gap-y-[5rem] mt-[3.75rem]"
-        style={{ overflow: 'visible' }}
-      >
-        {steps.map((step) => (
-          <div key={step.stepId} className="flex flex-col">
-            <StepHeader
-              stepName={step.stepName}
-              stepId={step.stepId}
-              isOpen={openStepIds.includes(step.stepId)}
-              onToggle={() => toggleStep(step.stepId)}
-              showDelete={step.tasks.length === 0}
-              onDelete={() => handleDeleteStep(step.stepId)}
-              onUpdateName={handleUpdateStepName}
-            />
-            {openStepIds.includes(step.stepId) && (
-              <Droppable droppableId={step.stepId.toString()}>
-                {(provided) => (
-                  <div
-                    ref={provided.innerRef}
-                    {...provided.droppableProps}
-                    className="flex flex-col mt-6 min-h-[0.625rem]"
-                    style={{ overflow: 'visible' }}
-                  >
-                    {step.tasks.map((task, idx) => (
-                      <Draggable
-                        key={`${step.stepId}-${task.taskId}`}
-                        draggableId={task.taskId.toString()}
-                        index={idx}
-                      >
-                        {(provided, snapshot) => (
-                          <div
-                            ref={provided.innerRef}
-                            {...provided.draggableProps}
-                            className={`mb-3 last:mb-0 transition-all duration-200 ${snapshot.isDragging ? 'opacity-50 z-50' : ''}`}
-                            style={{
-                              ...provided.draggableProps.style,
-                              width: '325px',
-                              height: 'auto',
-                            }}
-                          >
-                            <div {...provided.dragHandleProps}>
-                              <TaskItem
-                                projectId={projectId}
-                                id={task.taskId}
-                                title={task.taskName}
-                                status={mapTaskStatus(task.status)}
-                                deadline={task.deadline}
-                                assignee={task.managers.map((manager) => ({
-                                  name: manager.name,
-                                  imageUrl: manager.imageUrl,
-                                }))}
-                              />
+    <>
+      <DragDropContext onDragEnd={onDragEnd}>
+        <div
+          className="grid [grid-template-columns:repeat(2,20.313rem)] lg:[grid-template-columns:repeat(4,20.313rem)] gap-x-[2.25rem] gap-y-[5rem] mt-[3.75rem]"
+          style={{ overflow: 'visible' }}
+        >
+          {steps.map((step) => (
+            <div key={step.stepId} className="flex flex-col">
+              <StepHeader
+                stepName={step.stepName}
+                stepId={step.stepId}
+                isOpen={openStepIds.includes(step.stepId)}
+                onToggle={() => toggleStep(step.stepId)}
+                showDelete={step.tasks.length === 0}
+                onDelete={() => handleDeleteStep(step.stepId)}
+                onUpdateName={handleUpdateStepName}
+              />
+              {openStepIds.includes(step.stepId) && (
+                <Droppable droppableId={step.stepId.toString()}>
+                  {(provided) => (
+                    <div
+                      ref={provided.innerRef}
+                      {...provided.droppableProps}
+                      className="flex flex-col mt-6 min-h-[0.625rem]"
+                      style={{ overflow: 'visible' }}
+                    >
+                      {step.tasks.map((task, idx) => (
+                        <Draggable
+                          key={`${step.stepId}-${task.taskId}`}
+                          draggableId={task.taskId.toString()}
+                          index={idx}
+                        >
+                          {(provided, snapshot) => (
+                            <div
+                              ref={provided.innerRef}
+                              {...provided.draggableProps}
+                              className={`mb-3 last:mb-0 transition-all duration-200 ${snapshot.isDragging ? 'opacity-50 z-50' : ''}`}
+                              style={{
+                                ...provided.draggableProps.style,
+                                width: '325px',
+                                height: 'auto',
+                              }}
+                            >
+                              <div {...provided.dragHandleProps}>
+                                <TaskItem
+                                  projectId={String(projectId)}
+                                  id={task.taskId}
+                                  title={task.taskName}
+                                  status={mapTaskStatus(task.status)}
+                                  deadline={task.deadline}
+                                  assignee={task.managers.map((manager) => ({
+                                    name: manager.name,
+                                    imageUrl: manager.imageUrl,
+                                  }))}
+                                  onTaskComplete={handleTaskComplete}
+                                />
+                              </div>
                             </div>
-                          </div>
-                        )}
-                      </Draggable>
-                    ))}
+                          )}
+                        </Draggable>
+                      ))}
 
-                    {provided.placeholder}
+                      {provided.placeholder}
 
-                    <div className="mt-2">
-                      <AddTaskButton stepId={step.stepId} stepName={step.stepName} />
+                      <div className="mt-2">
+                        <AddTaskButton stepId={step.stepId} stepName={step.stepName} />
+                      </div>
                     </div>
-                  </div>
-                )}
-              </Droppable>
-            )}
-          </div>
-        ))}
-
-        {/* STEP 추가 버튼 */}
-        {canAddStep && (
-          <div className="flex flex-col">
-            <div className="flex bg-[#F8F8F8] w-full h-[4.25rem] items-center justify-center rounded-[0.5rem]">
-              <button
-                onClick={handleAddStep}
-                className="w-full h-full font-medium text-[1.125rem] transition-colors duration-200 text-[#898989] cursor-pointer hover:text-[#666666]"
-              >
-                + STEP 추가
-              </button>
+                  )}
+                </Droppable>
+              )}
             </div>
-          </div>
-        )}
-      </div>
-    </DragDropContext>
+          ))}
+
+          {/* STEP 추가 버튼 */}
+          {canAddStep && (
+            <div className="flex flex-col">
+              <div className="flex bg-[#F8F8F8] w-full h-[4.25rem] items-center justify-center rounded-[0.5rem]">
+                <button
+                  onClick={handleAddStep}
+                  className="w-full h-full font-medium text-[1.125rem] transition-colors duration-200 text-[#898989] cursor-pointer hover:text-[#666666]"
+                >
+                  + STEP 추가
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </DragDropContext>
+
+      {/* CopyModal */}
+      {showCopyModal && completedTask && (
+        <Portal>
+          <CopyModal
+            isOpen={showCopyModal}
+            onClose={handleCloseModal}
+            headerText="업무가 완료되었습니다.<br>피드백 요청을 위한 메세지를 복사하여<br>팀원들에게 전달하세요."
+            messageContent={
+              <>
+                💼 {completedTask.title} 업무가 완료되었어요!
+                <br />
+                확인 후 간단한 피드백을 남겨주세요.
+                <br />
+                👉{' '}
+                <Link
+                  href={getTaskUrl(completedTask.taskId)}
+                  className="underline font-bold text-[#81D7D4]"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {completedTask.title}
+                </Link>
+              </>
+            }
+            textToCopy={getTextToCopy(completedTask.title, completedTask.taskId)}
+            copySuccessText="업무 완료 메세지가 복사되었습니다."
+            innerPaddingX="5rem"
+          />
+        </Portal>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## 연관 이슈
- Closes #189

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
아예 TaskItem과 각 Board에서의 상태 관리 로직을 싹 수정했습니다. 이에 따라 TaskItem 컴포넌트의 prop이 변경되었습니다. 기존에는 모달 상태를 내부적으로 관리했지만, 이제 onTaskComplete 콜백 함수를 필수로 전달해야 합니다.

- 문제점:
  - TaskItem의 자체 상태는 부모의 리렌더링 시 초기화되어 모달이 사라짐.
  - 쿼리 무효화가 누락된 컴포넌트에서는 UI와 데이터가 불일치하는 버그 발생.

- 해결책:
  - '상태 끌어올리기' 패턴을 적용하여 모달 상태 관리 책임을 부모 컴포넌트(MyTaskBoard, StepsBoard 등)로 이전함.
  - TaskItem은 이제 상태를 갖지 않고 onTaskComplete 콜백만 호출함.

이제 모든 보드에서 일관된 모달 동작 보장됩니다!

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-
