### PR TITLE
[Feat/193] 업무 카드 리다이렉트

### DIFF
--- a/src/features/boards/MyTaskBoard.tsx
+++ b/src/features/boards/MyTaskBoard.tsx
@@ -73,7 +73,7 @@ export default function MyTaskBoard() {
   return (
     <>
       <div
-        className="grid [grid-template-columns:repeat(2,20.313rem)] lg:[grid-template-columns:repeat(4,20.313rem)] gap-x-[2.25rem] gap-y-[5rem] mt-[3.75rem] min-w-[64rem] overflow-x-auto"
+        className="grid [grid-template-columns:repeat(2,20.313rem)] lg:[grid-template-columns:repeat(4,20.313rem)] gap-x-[2.25rem] gap-y-[5rem] mt-[3.75rem] min-w-[64rem]"
         style={{ paddingLeft: 'clamp(43px, calc(112px - ((100vw - 1024px) * 0.077)), 112px)' }}
       >
         {projects.map((project) => (

--- a/src/features/boards/components/AddTaskButton.tsx
+++ b/src/features/boards/components/AddTaskButton.tsx
@@ -1,4 +1,6 @@
 import { useCreateTask } from '@/hooks/mutations/useCreateTask';
+import { useRouter } from 'next/navigation';
+import { useParams } from 'next/navigation';
 
 interface AddTaskButtonProps {
   stepId: number;
@@ -8,11 +10,18 @@ interface AddTaskButtonProps {
 
 export default function AddTaskButton({ stepId, className = '' }: AddTaskButtonProps) {
   const createTaskMutation = useCreateTask();
+  const router = useRouter();
+  const params = useParams();
+  const projectId = params.projectId as string;
 
   const handleClick = async () => {
     try {
-      await createTaskMutation.mutateAsync(stepId);
-      // 성공 시 쿼리 무효화로 자동으로 데이터가 업데이트됩니다
+      const response = await createTaskMutation.mutateAsync(stepId);
+
+      // 성공 시 생성된 업무의 상세 페이지로 리다이렉트
+      if (response.result?.taskId) {
+        router.push(`/projects/${projectId}/tasks/${response.result.taskId}`);
+      }
     } catch (error) {
       console.error('업무 생성 실패:', error);
       alert('업무 생성에 실패했습니다.');


### PR DESCRIPTION
## 연관 이슈
- Closes #193

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
업무 생성 시에 해당 업무 상세 페이지로 즉시 리다이렉트 되도록 합니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
나의 업무 페이지에서의 스크롤도 우선 삭제했습니다. 추후 논의가 필요합니다.

## 첨부 자료
-
