### PR TITLE
[Feat/221] PRO로 업그레이드 버튼 전역 상태 관리

### DIFF
--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -3,20 +3,18 @@
 import useToggle from '@/features/myPage/hooks/useToggle';
 import Tailored from '@/features/myPage/components/Tailored';
 import ToggleButton from '@/components/ToggleButton';
-import { useState } from 'react';
 import Projects from '@/features/myPage/components/Projects';
 import AddCorrectionButton from '@/features/myPage/components/AddCorrectionButton';
 import { useUser, useUpdateUserProfile } from '@/hooks/mutations/useUser';
 import ProfileImageUpload from '@/features/myPage/components/ProfileImageUpload';
 import EditableField from '@/features/myPage/components/EditableField';
+import { useAuth } from '@/contexts/AuthContext';
 
 export default function MyPage() {
   const { selected, setSelected } = useToggle();
   const { data, isLoading, error } = useUser();
   const updateUserProfile = useUpdateUserProfile();
-
-  // Pro로 업그레이드 시에 만 토글이 보이도록 설정
-  const [showToggle, setShowToggle] = useState(false);
+  const { isUpgraded, setIsUpgraded } = useAuth(); // AuthContext에서 pro 업그레이드 상태와 설정 함수 가져오기
 
   const handleProfileImageChange = (file: File) => {
     updateUserProfile.mutate(
@@ -157,8 +155,8 @@ export default function MyPage() {
                 <div className="text-black">{data?.projectNum}</div>
               </div>
             </div>
-            <button className="cursor-pointer" onClick={() => setShowToggle(true)}>
-              {!showToggle && (
+            <button className="cursor-pointer" onClick={() => setIsUpgraded(!isUpgraded)}>
+              {!isUpgraded && (
                 <img
                   src="/icons/Upgrade-pro.svg"
                   alt="UpgradePro"
@@ -166,7 +164,7 @@ export default function MyPage() {
                   max-lg:translate-x-[-43.8rem] max-lg:translate-y-[3.75rem]"
                 />
               )}
-              {showToggle && (
+              {isUpgraded && (
                 <div
                   className="flex flex-col
                 max-lg:translate-x-[-43.125rem] max-lg:translate-y-[4.375rem]"
@@ -211,8 +209,8 @@ export default function MyPage() {
             <h2 className="text-[1.375rem] font-bold ">포트폴리오</h2>
             <div className="flex items-center gap-4 h-[20px]">
               {/* AI 첨삭일 때만 + 버튼 표시 */}
-              {showToggle && selected === 'ai' && <AddCorrectionButton />}
-              {showToggle && (
+              {isUpgraded && selected === 'ai' && <AddCorrectionButton />}
+              {isUpgraded && (
                 <ToggleButton
                   leftLabel="프로젝트"
                   rightLabel="AI 첨삭"

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -12,12 +12,11 @@ import Image from 'next/image';
 
 export default function Navbar() {
   const [openMenu, setOpenMenu] = useState<string | null>(null);
-  const [isUpgraded, setIsUpgraded] = useState(false);
   const [isProfileDropdownOpen, setIsProfileDropdownOpen] = useState(false);
   const [selectedProject, setSelectedProject] = useState<string>('나의 프로젝트');
   const navbarRef = useRef<HTMLDivElement>(null);
   const pathname = usePathname();
-  const { user, logout } = useAuth(); // AuthContext에서 사용자 정보와 로그아웃 함수 가져오기
+  const { user, logout, isUpgraded, setIsUpgraded } = useAuth(); // AuthContext에서 사용자 정보와 로그아웃 함수, pro 업그레이드 상태 가져오기
 
   const toggleMenu = (menuKey: string) => {
     setOpenMenu((prev) => (prev === menuKey ? null : menuKey));
@@ -98,7 +97,7 @@ export default function Navbar() {
   ];
 
   const upgradeButtonClick = () => {
-    setIsUpgraded((prev) => !prev);
+    setIsUpgraded(!isUpgraded);
   };
 
   return (

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -19,6 +19,9 @@ interface AuthContextType {
   user: UserProfile | null;
   logout: () => Promise<void>;
   isLoading: boolean;
+  // pro 업그레이드 토글 상태 추가
+  isUpgraded: boolean;
+  setIsUpgraded: (value: boolean) => void;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -33,6 +36,8 @@ export const useAuth = () => {
 
 export const AuthProvider = ({ children }: PropsWithChildren) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  // pro 업그레이드 상태 추가
+  const [isUpgraded, setIsUpgraded] = useState(false);
   const { data: userData, error: userError, isLoading } = useUser();
   const { data: projects = [] } = useUserProjects(!!userData);
   const logoutMutation = useLogout();
@@ -89,8 +94,10 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
       user,
       logout,
       isLoading,
+      isUpgraded,
+      setIsUpgraded,
     }),
-    [isAuthenticated, user, isLoading]
+    [isAuthenticated, user, isLoading, isUpgraded]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;


### PR DESCRIPTION
## 연관 이슈
- Closes #221

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
PRO 유저 상태를 전역으로 관리하여 Navbar와 myPage에서 동일한 UI를 띄우도록 했습니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-
