### PR TITLE
[Feat/195] 업무 대시보드 페이지 프로젝트 종료시 스텝 및 업무 카드 ReadOnly

### DIFF
--- a/src/app/(main)/projects/[projectId]/dashboard/page.tsx
+++ b/src/app/(main)/projects/[projectId]/dashboard/page.tsx
@@ -7,6 +7,7 @@ import ToggleButton from '@/components/ToggleButton';
 import StepsBoard from '@/features/boards/StepsBoard';
 import StatusBoard from '@/features/boards/StatusBoard';
 import { useGetDashboard } from '@/hooks/queries/useGetDashboard';
+import { useGetProjectIsCompleted } from '@/hooks/queries/projects/useGetProject';
 import { useWebSocket } from '@/contexts/WebSocketContext';
 import {
   SubEventType,
@@ -48,6 +49,11 @@ export default function DashboardPage() {
 
   // 프로젝트 ID 파라미터 가져오기
   const { projectId } = useParams() as { projectId: string };
+
+  // 프로젝트 종료 여부 조회
+  const { data: isCompleted, isLoading: isStatusLoading } = useGetProjectIsCompleted(
+    parseInt(projectId)
+  );
 
   // 웹소켓 훅 사용
   const { socket, subscribe, unsubscribe, isConnected } = useWebSocket();
@@ -226,8 +232,8 @@ export default function DashboardPage() {
   // 현재 표시할 데이터 결정 (필터링된 데이터 또는 원본 데이터)
   const displayData = isFiltered ? filteredData : dashboardData;
 
-  // 로딩 상태 처리
-  if (isLoading) {
+  // 로딩 상태 처리 (프로젝트 상태도 함께 체크)
+  if (isLoading || isStatusLoading) {
     return (
       <div className="min-h-screen w-full bg-white flex items-center justify-center">
         <div className="text-lg">로딩 중...</div>
@@ -299,6 +305,7 @@ export default function DashboardPage() {
             <StepsBoard
               steps={displayData && 'steps' in displayData ? displayData.steps : []}
               projectId={projectId}
+              isCompleted={Boolean(isCompleted?.result?.isCompleted)}
             />
           ) : (
             <StatusBoard
@@ -306,6 +313,7 @@ export default function DashboardPage() {
                 displayData && 'statusGroups' in displayData ? displayData.statusGroups : []
               }
               projectId={projectId}
+              isCompleted={Boolean(isCompleted?.result?.isCompleted)}
             />
           )}
         </div>

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -10,6 +10,7 @@ import { formatToKoreanDate } from '@/utils/formatDate';
 // TaskItem 컴포넌트 Props에 onTaskComplete 콜백 추가
 interface TaskItemProps extends TaskItemComponentProps {
   onTaskComplete?: (taskId: number, title: string) => void;
+  isCompleted?: boolean;
 }
 
 export default function TaskItem({
@@ -20,6 +21,7 @@ export default function TaskItem({
   deadline,
   assignee,
   onTaskComplete,
+  isCompleted = false,
 }: TaskItemProps) {
   const { displayAssignees, deadlineTextColor } = useTaskItems({
     task: { id: taskId, title, status, deadline, assignee },
@@ -35,6 +37,9 @@ export default function TaskItem({
 
   const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.stopPropagation();
+
+    // 프로젝트가 종료된 경우 체크박스 비활성화
+    if (isCompleted) return;
 
     // 현재 상태에 따라 토글
     let newStatus: 'ONGOING' | 'COMPLETED';
@@ -72,7 +77,10 @@ export default function TaskItem({
             type="checkbox"
             checked={isChecked}
             onChange={handleCheckboxChange}
-            className="peer appearance-none w-[20px] h-[20px] border-2 border-[#898989] rounded bg-white cursor-pointer checked:bg-[#81D7D4]"
+            disabled={isCompleted}
+            className={`peer appearance-none w-[20px] h-[20px] border-2 border-[#898989] rounded bg-white ${
+              isCompleted ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer checked:bg-[#81D7D4]'
+            }`}
             onClick={stop}
             onMouseDown={stop}
             onTouchStart={stop}

--- a/src/features/boards/StatusBoard.tsx
+++ b/src/features/boards/StatusBoard.tsx
@@ -112,7 +112,8 @@ export default function StatusBoard({ statusGroups, projectId, isCompleted }: St
 
   // 복사될 링크 URL
   const getTaskUrl = (taskId: number) => {
-    return `/projects/${projectId}/tasks/${taskId}`;
+    const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
+    return `${baseUrl}/projects/${projectId}/tasks/${taskId}`;
   };
 
   // 클립보드에 복사될 순수 텍스트

--- a/src/features/boards/StatusBoard.tsx
+++ b/src/features/boards/StatusBoard.tsx
@@ -9,7 +9,7 @@ import CopyModal from '@/components/CopyModal';
 import Portal from '@/components/Portal';
 import Link from 'next/link';
 
-export default function StatusBoard({ statusGroups, projectId }: StatusBoardProps) {
+export default function StatusBoard({ statusGroups, projectId, isCompleted }: StatusBoardProps) {
   const updateTaskStatusMutation = useUpdateTaskStatus();
   const [showCopyModal, setShowCopyModal] = useState(false);
   const [completedTask, setCompletedTask] = useState<{ title: string; taskId: number } | null>(
@@ -46,6 +46,9 @@ export default function StatusBoard({ statusGroups, projectId }: StatusBoardProp
 
   // 드래그가 끝났을 때 호출되는 함수
   const onDragEnd = async (result: DropResult) => {
+    // 프로젝트가 종료된 경우 DnD 비활성화
+    if (isCompleted) return;
+
     const { source, destination } = result;
 
     // 드롭할 위치가 없으면 아무것도 안 함
@@ -108,8 +111,9 @@ export default function StatusBoard({ statusGroups, projectId }: StatusBoardProp
   );
 
   // 복사될 링크 URL
-  const getTaskUrl = (taskId: number) =>
-    `http://localhost:3000/projects/${projectId}/tasks/${taskId}`;
+  const getTaskUrl = (taskId: number) => {
+    return `/projects/${projectId}/tasks/${taskId}`;
+  };
 
   // 클립보드에 복사될 순수 텍스트
   const getTextToCopy = (title: string, taskId: number) =>
@@ -131,7 +135,7 @@ export default function StatusBoard({ statusGroups, projectId }: StatusBoardProp
                 {status}
               </div>
 
-              <Droppable droppableId={status}>
+              <Droppable droppableId={status} isDropDisabled={isCompleted}>
                 {(provided) => (
                   <div
                     ref={provided.innerRef}
@@ -144,6 +148,7 @@ export default function StatusBoard({ statusGroups, projectId }: StatusBoardProp
                         key={task.taskId}
                         draggableId={task.taskId.toString()}
                         index={index}
+                        isDragDisabled={isCompleted}
                       >
                         {(provided, snapshot) => (
                           <div
@@ -167,7 +172,11 @@ export default function StatusBoard({ statusGroups, projectId }: StatusBoardProp
                                   name: manager.name,
                                   imageUrl: manager.imageUrl,
                                 }))}
+                                isCompleted={isCompleted}
                                 onTaskComplete={(taskId, title) => {
+                                  // 프로젝트가 종료된 경우 완료 처리 비활성화
+                                  if (isCompleted) return;
+
                                   // 완료 상태로 변경된 경우 모달 표시
                                   setCompletedTask({ title, taskId });
                                   setShowCopyModal(true);

--- a/src/features/boards/StepsBoard.tsx
+++ b/src/features/boards/StepsBoard.tsx
@@ -14,7 +14,7 @@ import CopyModal from '@/components/CopyModal';
 import Portal from '@/components/Portal';
 import Link from 'next/link';
 
-export default function StepsBoard({ steps, projectId }: StepsBoardProps) {
+export default function StepsBoard({ steps, projectId, isCompleted }: StepsBoardProps) {
   const { openStepIds, toggleStep, openStep } = useSteps();
   const createStepMutation = useCreateStep();
   const deleteStepMutation = useDeleteStep();
@@ -27,8 +27,8 @@ export default function StepsBoard({ steps, projectId }: StepsBoardProps) {
     null
   );
 
-  // STEP 추가 제한 (최대 8개)
-  const canAddStep = steps.length < 8;
+  // STEP 추가 제한 (최대 8개, 프로젝트 종료 시 비활성화)
+  const canAddStep = steps.length < 8 && !isCompleted;
 
   // 상태 매핑 함수 (API 상태를 표시 텍스트로 변환)
   const mapTaskStatus = (status: string) => {
@@ -55,8 +55,9 @@ export default function StepsBoard({ steps, projectId }: StepsBoardProps) {
   };
 
   // 복사될 링크 URL
-  const getTaskUrl = (taskId: number) =>
-    `http://localhost:3000/projects/${projectId}/tasks/${taskId}`;
+  const getTaskUrl = (taskId: number) => {
+    return `/projects/${projectId}/tasks/${taskId}`;
+  };
 
   // 클립보드에 복사될 순수 텍스트
   const getTextToCopy = (title: string, taskId: number) =>
@@ -64,7 +65,7 @@ export default function StepsBoard({ steps, projectId }: StepsBoardProps) {
 
   // STEP 추가 처리
   const handleAddStep = async () => {
-    if (!canAddStep) return;
+    if (!canAddStep || isCompleted) return;
 
     try {
       const response = await createStepMutation.mutateAsync({
@@ -84,6 +85,9 @@ export default function StepsBoard({ steps, projectId }: StepsBoardProps) {
 
   // STEP 삭제 처리
   const handleDeleteStep = async (stepId: number) => {
+    // 프로젝트가 종료된 경우 삭제 비활성화
+    if (isCompleted) return;
+
     // if (!confirm('정말로 이 STEP을 삭제하시겠습니까?')) {
     //   return;
     // }
@@ -110,6 +114,9 @@ export default function StepsBoard({ steps, projectId }: StepsBoardProps) {
 
   // 드래그가 끝났을 때 호출되는 함수
   const onDragEnd = async (result: DropResult) => {
+    // 프로젝트가 종료된 경우 DnD 비활성화
+    if (isCompleted) return;
+
     const { source, destination } = result;
 
     // 드롭할 위치가 없으면 아무것도 안 함
@@ -160,21 +167,21 @@ export default function StepsBoard({ steps, projectId }: StepsBoardProps) {
           {steps.map((step) => (
             <div key={step.stepId} className="flex flex-col">
               <StepHeader
-                stepName={step.stepName}
-                stepId={step.stepId}
+                step={step}
                 isOpen={openStepIds.includes(step.stepId)}
                 onToggle={() => toggleStep(step.stepId)}
-                showDelete={step.tasks.length === 0}
-                onDelete={() => handleDeleteStep(step.stepId)}
-                onUpdateName={handleUpdateStepName}
+                onDelete={handleDeleteStep}
+                onUpdate={handleUpdateStepName}
+                isCompleted={isCompleted}
               />
+
               {openStepIds.includes(step.stepId) && (
-                <Droppable droppableId={step.stepId.toString()}>
+                <Droppable droppableId={step.stepId.toString()} isDropDisabled={isCompleted}>
                   {(provided) => (
                     <div
                       ref={provided.innerRef}
                       {...provided.droppableProps}
-                      className="flex flex-col mt-6 min-h-[0.625rem]"
+                      className="mt-4 space-y-3"
                       style={{ overflow: 'visible' }}
                     >
                       {step.tasks.map((task, idx) => (
@@ -182,6 +189,7 @@ export default function StepsBoard({ steps, projectId }: StepsBoardProps) {
                           key={`${step.stepId}-${task.taskId}`}
                           draggableId={task.taskId.toString()}
                           index={idx}
+                          isDragDisabled={isCompleted}
                         >
                           {(provided, snapshot) => (
                             <div
@@ -205,7 +213,12 @@ export default function StepsBoard({ steps, projectId }: StepsBoardProps) {
                                     name: manager.name,
                                     imageUrl: manager.imageUrl,
                                   }))}
-                                  onTaskComplete={handleTaskComplete}
+                                  isCompleted={isCompleted}
+                                  onTaskComplete={(taskId, title) => {
+                                    // 프로젝트가 종료된 경우 완료 처리 비활성화
+                                    if (isCompleted) return;
+                                    handleTaskComplete(taskId, title);
+                                  }}
                                 />
                               </div>
                             </div>
@@ -216,7 +229,11 @@ export default function StepsBoard({ steps, projectId }: StepsBoardProps) {
                       {provided.placeholder}
 
                       <div className="mt-2">
-                        <AddTaskButton stepId={step.stepId} stepName={step.stepName} />
+                        <AddTaskButton
+                          stepId={step.stepId}
+                          stepName={step.stepName}
+                          isCompleted={isCompleted}
+                        />
                       </div>
                     </div>
                   )}

--- a/src/features/boards/StepsBoard.tsx
+++ b/src/features/boards/StepsBoard.tsx
@@ -56,7 +56,8 @@ export default function StepsBoard({ steps, projectId, isCompleted }: StepsBoard
 
   // 복사될 링크 URL
   const getTaskUrl = (taskId: number) => {
-    return `/projects/${projectId}/tasks/${taskId}`;
+    const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
+    return `${baseUrl}/projects/${projectId}/tasks/${taskId}`;
   };
 
   // 클립보드에 복사될 순수 텍스트

--- a/src/features/boards/components/AddTaskButton.tsx
+++ b/src/features/boards/components/AddTaskButton.tsx
@@ -34,8 +34,8 @@ export default function AddTaskButton({ stepId, className = '', isCompleted }: A
 
   return (
     <button
-      className={`flex bg-[#FFFFFF] text-[#898989] w-[20.313rem] h-[2.75rem] items-center justify-center rounded-[0.5rem] text-[1rem] cursor-pointer border border-[#BBBBBB] ${
-        isCompleted ? 'opacity-50 cursor-not-allowed' : 'hover:bg-[#F8F8F8]'
+      className={`flex bg-[#FFFFFF] text-[#898989] w-[20.313rem] h-[2.75rem] items-center justify-center rounded-[0.5rem] text-[1rem] border border-[#BBBBBB] ${
+        isCompleted ? 'opacity-50 cursor-not-allowed' : 'hover:bg-[#F8F8F8] cursor-pointer'
       } ${className}`}
       onClick={handleClick}
       disabled={createTaskMutation.isPending || isCompleted}

--- a/src/features/boards/components/AddTaskButton.tsx
+++ b/src/features/boards/components/AddTaskButton.tsx
@@ -6,15 +6,19 @@ interface AddTaskButtonProps {
   stepId: number;
   stepName: string;
   className?: string;
+  isCompleted: boolean;
 }
 
-export default function AddTaskButton({ stepId, className = '' }: AddTaskButtonProps) {
+export default function AddTaskButton({ stepId, className = '', isCompleted }: AddTaskButtonProps) {
   const createTaskMutation = useCreateTask();
   const router = useRouter();
   const params = useParams();
   const projectId = params.projectId as string;
 
   const handleClick = async () => {
+    // 프로젝트가 종료된 경우 업무 추가 비활성화
+    if (isCompleted) return;
+
     try {
       const response = await createTaskMutation.mutateAsync(stepId);
 
@@ -30,9 +34,11 @@ export default function AddTaskButton({ stepId, className = '' }: AddTaskButtonP
 
   return (
     <button
-      className={`flex bg-[#FFFFFF] text-[#898989] w-[20.313rem] h-[2.75rem] items-center justify-center rounded-[0.5rem] text-[1rem] cursor-pointer border border-[#BBBBBB] ${className}`}
+      className={`flex bg-[#FFFFFF] text-[#898989] w-[20.313rem] h-[2.75rem] items-center justify-center rounded-[0.5rem] text-[1rem] cursor-pointer border border-[#BBBBBB] ${
+        isCompleted ? 'opacity-50 cursor-not-allowed' : 'hover:bg-[#F8F8F8]'
+      } ${className}`}
       onClick={handleClick}
-      disabled={createTaskMutation.isPending}
+      disabled={createTaskMutation.isPending || isCompleted}
     >
       + 업무 추가
     </button>

--- a/src/features/boards/components/StepHeader.tsx
+++ b/src/features/boards/components/StepHeader.tsx
@@ -1,55 +1,58 @@
 import { useState } from 'react';
 import Image from 'next/image';
+import { Task } from '@/types/api/tasks';
 
 interface StepHeaderProps {
-  stepName: string;
-  stepId: number;
+  step: {
+    stepName: string;
+    stepId: number;
+    tasks: Task[];
+  };
   isOpen: boolean;
   onToggle: () => void;
-  showDelete?: boolean;
-  onDelete?: () => void;
-  onUpdateName?: (stepId: number, newName: string) => Promise<void>;
+  onDelete: (stepId: number) => void;
+  onUpdate: (stepId: number, newName: string) => Promise<void>;
+  isCompleted: boolean;
 }
 
 export default function StepHeader({
-  stepName,
-  stepId,
+  step,
   isOpen,
   onToggle,
-  showDelete,
   onDelete,
-  onUpdateName,
+  onUpdate,
+  isCompleted,
 }: StepHeaderProps) {
   const [isHovered, setIsHovered] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
-  const [editName, setEditName] = useState(stepName);
+  const [editName, setEditName] = useState(step.stepName);
 
   const handleIconClick = (e: React.MouseEvent | React.KeyboardEvent) => {
     e.stopPropagation();
-    if (onDelete) onDelete();
+    if (onDelete && !isCompleted) onDelete(step.stepId);
   };
 
   const handleDoubleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (onUpdateName) {
+    if (!isCompleted) {
       setIsEditing(true);
-      setEditName(stepName);
+      setEditName(step.stepName);
     }
   };
 
   const handleBlur = async () => {
-    if (!onUpdateName) return;
+    if (!onUpdate || isCompleted) return;
 
     const trimmedName = editName.trim();
-    if (trimmedName && trimmedName !== stepName) {
+    if (trimmedName && trimmedName !== step.stepName) {
       try {
-        await onUpdateName(stepId, trimmedName);
+        await onUpdate(step.stepId, trimmedName);
       } catch (error) {
         console.error('스텝 이름 수정 실패:', error);
-        setEditName(stepName); // 실패 시 원래 이름으로 복원
+        setEditName(step.stepName); // 실패 시 원래 이름으로 복원
       }
     } else {
-      setEditName(stepName); // 빈 값이거나 변경사항이 없으면 원래 이름으로 복원
+      setEditName(step.stepName); // 빈 값이거나 변경사항이 없으면 원래 이름으로 복원
     }
     setIsEditing(false);
   };
@@ -59,10 +62,13 @@ export default function StepHeader({
       e.preventDefault();
       e.currentTarget.blur();
     } else if (e.key === 'Escape') {
-      setEditName(stepName);
+      setEditName(step.stepName);
       setIsEditing(false);
     }
   };
+
+  // 삭제 가능 여부 (업무가 없고 프로젝트가 종료되지 않은 경우)
+  const showDelete = step.tasks.length === 0 && !isCompleted;
 
   return (
     <div
@@ -84,10 +90,10 @@ export default function StepHeader({
             />
           ) : (
             <span
-              className="font-medium text-[1.125rem] cursor-pointer"
+              className={`font-medium text-[1.125rem] ${!isCompleted ? 'cursor-pointer' : 'cursor-default'}`}
               onDoubleClick={handleDoubleClick}
             >
-              {stepName}
+              {step.stepName}
             </span>
           )}
           {showDelete && isHovered ? (

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -4,9 +4,11 @@ import { StatusGroup } from '@/types/api/dashboard';
 export interface StepsBoardProps {
   steps: Step[];
   projectId: string;
+  isCompleted: boolean;
 }
 
 export interface StatusBoardProps {
   statusGroups: StatusGroup[];
   projectId: string;
+  isCompleted: boolean;
 }


### PR DESCRIPTION
## 연관 이슈
- Closes #195 

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
프로젝트 종료 시에 업무 생성, STEP 생성, 수정, 삭제, DnD, TaskItem 완료 버튼 등이 다 비활성화됩니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-
