### PR TITLE
[Feat/222] 팀캘린더 UI 수정사항 반영

### DIFF
--- a/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
+++ b/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
@@ -43,12 +43,15 @@ export default function TeamCalendar() {
   const queryClient = useQueryClient();
   const { socket, subscribe, unsubscribe, isConnected } = useWebSocket();
 
-  // 현재 보고 있는 달의 첫 날 ~ 마지막 날 계산
+  // 현재 월 + 이전/다음 월 일부 포함하여 조회
   const startDate = useMemo(
-    () => moment(currentDate).startOf('month').toISOString(),
+    () => moment(currentDate).subtract(1, 'month').startOf('month').toISOString(),
     [currentDate]
   );
-  const endDate = useMemo(() => moment(currentDate).endOf('month').toISOString(), [currentDate]);
+  const endDate = useMemo(
+    () => moment(currentDate).add(1, 'month').endOf('month').toISOString(),
+    [currentDate]
+  );
 
   // API 요청: 일정 목록
   const {
@@ -254,7 +257,7 @@ export default function TeamCalendar() {
       console.warn('onSelectEvent: 유효하지 않은 이벤트 또는 projectId 누락', { projectId, event });
       return;
     }
-    const target = `/projects/${projectId}/teamcalendar/${event.id}/teamtask`;
+    const target = `/projects/${projectId}/teamCalendar/${event.id}/teamTask`;
     console.log('onSelectEvent: 팀태스크로 이동', {
       projectId,
       planId: event.id,

--- a/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
+++ b/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
@@ -45,20 +45,17 @@ export default function TeamCalendar() {
 
   // 현재 월 + 이전/다음 월 일부 포함하여 조회
   const startDate = useMemo(
-    () => moment(currentDate).subtract(1, 'month').startOf('month').toISOString(),
+    () => moment(currentDate).startOf('month').toISOString(),
     [currentDate]
   );
-  const endDate = useMemo(
-    () => moment(currentDate).add(1, 'month').endOf('month').toISOString(),
-    [currentDate]
-  );
+  const endDate = useMemo(() => moment(currentDate).endOf('month').toISOString(), [currentDate]);
 
   // API 요청: 일정 목록
-  const {
-    data: calendarData,
-    isLoading,
-    refetch, // ✅ refetch 포함
-  } = useGetCalendarPlans(projectId ?? '', startDate, endDate);
+  const { data: calendarData, isLoading } = useGetCalendarPlans(
+    projectId ?? '',
+    startDate,
+    endDate
+  );
 
   console.log('calendarData', calendarData);
 
@@ -121,17 +118,16 @@ export default function TeamCalendar() {
     endDate,
   ]);
 
-  // ✅ 창이 다시 focus될 때 refetch 실행
-  useEffect(() => {
-    const handleFocus = () => {
-      refetch();
-    };
-
-    window.addEventListener('focus', handleFocus);
-    return () => {
-      window.removeEventListener('focus', handleFocus);
-    };
-  }, [refetch]);
+  // 창 포커스 refetch 제거
+  // useEffect(() => {
+  //   const handleFocus = () => {
+  //     refetch();
+  //   };
+  //   window.addEventListener('focus', handleFocus);
+  //   return () => {
+  //     window.removeEventListener('focus', handleFocus);
+  //   };
+  // }, [refetch]);
 
   // 프로젝트 생성일을 조회해 해당 일 이전 날짜 차단
   useEffect(() => {
@@ -309,7 +305,7 @@ export default function TeamCalendar() {
         >
           팀 캘린더
         </h2>
-        <hr className="w-full border-t-[2px] border-[#E7E7E7] rotate-180 mb-[44px]" />
+        <hr className=" w-[1500px] border-t-[2px] border-[#E7E7E7] rotate-180 mb-[44px] -ml-[10px]" />
       </div>
 
       {/* 월 네비게이션 */}

--- a/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
+++ b/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
@@ -43,12 +43,15 @@ export default function TeamCalendar() {
   const queryClient = useQueryClient();
   const { socket, subscribe, unsubscribe, isConnected } = useWebSocket();
 
-  // 현재 월 + 이전/다음 월 일부 포함하여 조회
+  // 현재 월 + 이전/다음 월 일부 포함하여 조회 (45일 범위로 확장)
   const startDate = useMemo(
-    () => moment(currentDate).startOf('month').toISOString(),
+    () => moment(currentDate).subtract(22, 'days').startOf('day').toISOString(),
     [currentDate]
   );
-  const endDate = useMemo(() => moment(currentDate).endOf('month').toISOString(), [currentDate]);
+  const endDate = useMemo(
+    () => moment(currentDate).add(22, 'days').endOf('day').toISOString(),
+    [currentDate]
+  );
 
   // API 요청: 일정 목록
   const { data: calendarData, isLoading } = useGetCalendarPlans(

--- a/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
+++ b/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
@@ -267,6 +267,9 @@ export default function TeamCalendar() {
   };
 
   const handlePrevMonth = () => {
+    // 프로젝트 생성일 이전 월로는 이동 불가
+    if (!canGoToPrevMonth) return;
+
     const [year, month, day] = [
       currentDate.getFullYear(),
       currentDate.getMonth(),
@@ -276,6 +279,21 @@ export default function TeamCalendar() {
     const prevYear = month === 0 ? year - 1 : year;
     setCurrentDate(new Date(prevYear, prevMonth, day));
   };
+
+  // 프로젝트 생성일 이후의 월만 조회 가능하도록 제한
+  const canGoToPrevMonth = useMemo(() => {
+    if (!projectCreatedAtISO) return true; // 생성일을 못 가져오면 제한 없음
+
+    // 현재 월의 시작일이 프로젝트 생성일 이전인지 확인
+    const currentMonthStart = moment(currentDate).startOf('month');
+    const isBeforeProjectCreation = moment(currentMonthStart).isBefore(
+      moment(projectCreatedAtISO),
+      'day'
+    );
+
+    // 프로젝트 생성일 이전 월이면 이동 불가
+    return !isBeforeProjectCreation;
+  }, [projectCreatedAtISO, currentDate]);
 
   const handleNextMonth = () => {
     const [year, month, day] = [
@@ -313,13 +331,19 @@ export default function TeamCalendar() {
 
       {/* 월 네비게이션 */}
       <div className="flex justify-start items-center font-semibold text-[20px] leading-[29px] text-black mb-[47px]">
-        <button onClick={handlePrevMonth}>
+        <button
+          onClick={handlePrevMonth}
+          disabled={!canGoToPrevMonth}
+          className={`flex items-center justify-center ${
+            canGoToPrevMonth ? 'cursor-pointer opacity-100' : 'cursor-not-allowed opacity-30'
+          }`}
+        >
           <Image
             src="/icons/Vector-left.svg"
             alt="왼쪽"
             width={24}
             height={24}
-            className="w-[24px] h-[24px] cursor-pointer"
+            className="w-[24px] h-[24px]"
           />
         </button>
         <span className="mx-4">{formattedTitle}</span>

--- a/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
+++ b/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
@@ -342,6 +342,7 @@ export default function TeamCalendar() {
         startAccessor="start"
         endAccessor="end"
         date={currentDate}
+        showAllEvents={true}
         onNavigate={() => {}} // 기본 이동 비활성화 (커스텀 버튼 사용 중)
         style={{ height: 'calc(100vh - 300px)', backgroundColor: 'white' }}
         components={{

--- a/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
+++ b/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
@@ -361,7 +361,7 @@ export default function TeamCalendar() {
         >
           팀 캘린더
         </h2>
-        <hr className=" w-[1500px] border-t-[2px] border-[#E7E7E7] rotate-180 mb-[44px] -ml-[15px]" />
+        <hr className=" w-[1490px] border-t-[2px] border-[#E7E7E7] rotate-180 mb-[44px] -ml-[15px]" />
       </div>
 
       {/* 월 네비게이션 */}
@@ -424,7 +424,7 @@ export default function TeamCalendar() {
             />
           ),
           event: (props) => (
-            <div className="relative z-[60] pointer-events-auto">
+            <div className="relative z-[90] pointer-events-auto">
               <CalendarEventBox {...props} />
             </div>
           ), // ✅ 커스텀 일정 카드 디자인 - 클릭 가능 보장
@@ -442,7 +442,7 @@ export default function TeamCalendar() {
               color: '#000000',
               borderRadius: '4px',
               position: 'relative',
-              zIndex: 60,
+              zIndex: 90,
             },
           };
         }}

--- a/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
+++ b/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
@@ -308,6 +308,41 @@ export default function TeamCalendar() {
 
   const formattedTitle = moment(currentDate).format('YYYY년 M월');
 
+  // 현재 월의 주 수 계산 (5주 또는 6주)
+  const weeksInMonth = useMemo(() => {
+    const firstDayOfMonth = moment(currentDate).startOf('month');
+    const lastDayOfMonth = moment(currentDate).endOf('month');
+
+    // 첫 번째 주의 시작일 (일요일)
+    const firstWeekStart = firstDayOfMonth.clone().startOf('week');
+    // 마지막 주의 끝일 (토요일)
+    const lastWeekEnd = lastDayOfMonth.clone().endOf('week');
+
+    // 주 수 계산
+    const weeks = lastWeekEnd.diff(firstWeekStart, 'weeks') + 1;
+    return weeks;
+  }, [currentDate]);
+
+  // 캘린더 높이 동적 계산 (기본 높이 208px 고정)
+  const calendarHeight = useMemo(() => {
+    const weekHeight = 208; // 각 주의 높이 (208px 고정)
+    const headerHeight = 40; // 요일 헤더 높이
+    const totalHeight = weeksInMonth * weekHeight + headerHeight;
+
+    return totalHeight;
+  }, [weeksInMonth]);
+
+  // 캘린더 높이 디버깅
+  useEffect(() => {
+    console.log('캘린더 정보:', {
+      month: formattedTitle,
+      weeksInMonth,
+      calendarHeight: `${calendarHeight}px`,
+      weekHeight: '208px (고정)',
+      headerHeight: '40px',
+    });
+  }, [formattedTitle, weeksInMonth, calendarHeight]);
+
   if (isLoading) {
     return (
       <div className="flex justify-center items-center min-h-[500px] text-lg">
@@ -326,7 +361,7 @@ export default function TeamCalendar() {
         >
           팀 캘린더
         </h2>
-        <hr className=" w-[1500px] border-t-[2px] border-[#E7E7E7] rotate-180 mb-[44px] -ml-[10px]" />
+        <hr className=" w-[1500px] border-t-[2px] border-[#E7E7E7] rotate-180 mb-[44px] -ml-[15px]" />
       </div>
 
       {/* 월 네비게이션 */}
@@ -371,7 +406,12 @@ export default function TeamCalendar() {
         date={currentDate}
         showAllEvents={true}
         onNavigate={() => {}} // 기본 이동 비활성화 (커스텀 버튼 사용 중)
-        style={{ height: 'calc(100vh - 300px)', backgroundColor: 'white' }}
+        style={{
+          width: '1400px',
+          height: `${calendarHeight}px`,
+          backgroundColor: 'white',
+          margin: '32px',
+        }}
         components={{
           dateCellWrapper: (props) => (
             <CustomDateCellWrapper

--- a/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
+++ b/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
@@ -443,6 +443,7 @@ export default function TeamCalendar() {
               borderRadius: '4px',
               position: 'relative',
               zIndex: 90,
+              marginBottom: '2px',
             },
           };
         }}

--- a/src/features/teamCalendar/CustomDateCellWrapper.tsx
+++ b/src/features/teamCalendar/CustomDateCellWrapper.tsx
@@ -95,7 +95,7 @@ export default function CustomDateCellWrapper({
 
   return (
     <div
-      className={`relative w-full h-full transition-all duration-200 rounded-[4px] overflow-visible ${hoverActive ? 'shadow-[0_0_10px_rgba(0,0,0,0.25)] cursor-pointer' : ''}`}
+      className={`relative w-full h-full transition-all duration-200 rounded-[4px] overflow-visible ${hoverActive ? 'shadow-[0_0_10px_rgba(0,0,0,0.25)] cursor-pointer z-[60]' : ''}`}
       onMouseEnter={() => {
         if (canShowPlusButton) setHovered(true);
       }}

--- a/src/features/teamCalendar/CustomDateCellWrapper.tsx
+++ b/src/features/teamCalendar/CustomDateCellWrapper.tsx
@@ -70,10 +70,10 @@ export default function CustomDateCellWrapper({
           });
           console.log('일정 목록 refetch 요청!');
 
-          router.push(`/projects/${projectId}/teamcalendar/${planId}/teamtask`);
+          router.push(`/projects/${projectId}/teamCalendar/${planId}/teamTask`);
           console.log(
             '상세 페이지로 이동:',
-            `/projects/${projectId}/teamcalendar/${planId}/teamtask`
+            `/projects/${projectId}/teamCalendar/${planId}/teamTask`
           );
         },
         onError: (error) => {

--- a/src/features/teamCalendar/CustomDateCellWrapper.tsx
+++ b/src/features/teamCalendar/CustomDateCellWrapper.tsx
@@ -88,14 +88,14 @@ export default function CustomDateCellWrapper({
   // 드래그 앤 드롭: 드래그 진입 시 상단 라인 인디케이터 표시
   const [isDragOver, setIsDragOver] = useState(false);
   const [indicatorY, setIndicatorY] = useState<number>(4);
-  const indicatorVisible = isDragOver && canShowPlusButton;
+  const indicatorVisible = isDragOver; // 호버 상태와 독립적으로 작동
 
   // 드롭할 목표 날짜 문자열 (로컬 자정)
   const dropTargetDate = useMemo(() => moment(value).format('YYYY-MM-DD[T]00:00:00'), [value]);
 
   return (
     <div
-      className={`relative w-full h-full transition-all duration-200 rounded-[4px] overflow-visible ${hoverActive ? 'shadow-[0_0_10px_rgba(0,0,0,0.25)] cursor-pointer z-[60]' : ''}`}
+      className={`relative w-full h-full transition-all duration-200 rounded-[4px] overflow-visible ${hoverActive ? 'shadow-[0_0_10px_rgba(0,0,0,0.25)] cursor-pointer' : ''}`}
       onMouseEnter={() => {
         if (canShowPlusButton) setHovered(true);
       }}
@@ -106,9 +106,11 @@ export default function CustomDateCellWrapper({
           e.dataTransfer.types.includes('application/x-teamie-plan') ||
           e.dataTransfer.types.includes('application/x-teamie-task') ||
           e.dataTransfer.types.includes('text/plain');
-        if (hasData && canShowPlusButton) {
+        if (hasData) {
           const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
-          const y = Math.max(12, Math.min(e.clientY - rect.top, rect.height - 12));
+          let y = e.clientY - rect.top;
+          // 셀 전체 영역에서 드래그 가능하도록 수정 (0부터 height까지)
+          y = Math.max(0, Math.min(y, rect.height));
           setIndicatorY(y);
           setIsDragOver(true);
         }
@@ -118,11 +120,13 @@ export default function CustomDateCellWrapper({
           e.dataTransfer.types.includes('application/x-teamie-plan') ||
           e.dataTransfer.types.includes('application/x-teamie-task') ||
           e.dataTransfer.types.includes('text/plain');
-        if (hasData && canShowPlusButton) {
+        if (hasData) {
           e.preventDefault();
           e.dataTransfer.dropEffect = 'move';
           const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
-          const y = Math.max(12, Math.min(e.clientY - rect.top, rect.height - 12));
+          let y = e.clientY - rect.top;
+          // 셀 전체 영역에서 드래그 가능하도록 수정 (0부터 height까지)
+          y = Math.max(0, Math.min(y, rect.height));
           setIndicatorY(y);
           setIsDragOver(true);
         }
@@ -208,10 +212,9 @@ export default function CustomDateCellWrapper({
       {/* 드래그 오버 라인 인디케이터 */}
       {indicatorVisible && (
         <div
-          className="pointer-events-none absolute left-1/2 -translate-x-1/2 "
+          className="pointer-events-none absolute inset-x-0"
           style={{
             top: indicatorY,
-            width: '100%',
             height: '3px',
             borderRadius: '10px',
             backgroundColor: '#81D7D4',
@@ -221,7 +224,7 @@ export default function CustomDateCellWrapper({
       )}
       {/* 플러스 버튼 - 가벼운 호버 센서 사용: 캘린더 이벤트 클릭을 막지 않음 */}
       {canShowPlusButton && (
-        <div className="absolute top-0 right-0 z-[70] w-[40px] h-[40px] pointer-events-auto">
+        <div className="absolute top-0 right-0 z-[90] w-[40px] h-[40px] pointer-events-auto">
           <div
             className="absolute top-[8px] right-[8px]"
             onMouseEnter={() => setHovered(true)}
@@ -232,13 +235,7 @@ export default function CustomDateCellWrapper({
                 className="flex items-center justify-center rounded-[4px] cursor-pointer"
                 onClick={handleClick}
               >
-                <Image
-                  src="/icons/AddProject.svg"
-                  alt="일정 추가"
-                  width={24}
-                  height={24}
-                  className="w-[24px] h-[24px]"
-                />
+                <Image src="/icons/AddProject.svg" alt="일정 추가" width={24} height={24} />
               </button>
             )}
           </div>

--- a/src/features/teamCalendar/CustomDateCellWrapper.tsx
+++ b/src/features/teamCalendar/CustomDateCellWrapper.tsx
@@ -95,7 +95,7 @@ export default function CustomDateCellWrapper({
 
   return (
     <div
-      className={`relative w-full h-full transition-all duration-200 rounded-[4px] overflow-visible ${hoverActive ? 'shadow-[0_0_10px_rgba(0,0,0,0.25)] cursor-pointer' : ''}`}
+      className={`relative w-full h-full transition-all duration-200 rounded-[4px] overflow-visible ${hoverActive ? 'shadow-[0_0_10px_rgba(0,0,0,0.25)] cursor-pointer z-[90px]' : ''}`}
       onMouseEnter={() => {
         if (canShowPlusButton) setHovered(true);
       }}
@@ -109,8 +109,8 @@ export default function CustomDateCellWrapper({
         if (hasData) {
           const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
           let y = e.clientY - rect.top;
-          // 셀 전체 영역에서 드래그 가능하도록 수정 (0부터 height까지)
-          y = Math.max(0, Math.min(y, rect.height));
+          // 셀 경계를 넘어서는 드롭 허용 (확장된 드롭 영역)
+          y = Math.max(-20, Math.min(y, rect.height + 20));
           setIndicatorY(y);
           setIsDragOver(true);
         }
@@ -125,8 +125,8 @@ export default function CustomDateCellWrapper({
           e.dataTransfer.dropEffect = 'move';
           const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
           let y = e.clientY - rect.top;
-          // 셀 전체 영역에서 드래그 가능하도록 수정 (0부터 height까지)
-          y = Math.max(0, Math.min(y, rect.height));
+          // 셀 경계를 넘어서는 드롭 허용 (확장된 드롭 영역)
+          y = Math.max(-20, Math.min(y, rect.height + 20));
           setIndicatorY(y);
           setIsDragOver(true);
         }

--- a/src/features/teamCalendar/components/CalendarEventBox.tsx
+++ b/src/features/teamCalendar/components/CalendarEventBox.tsx
@@ -49,11 +49,11 @@ export default function CalendarEventBox({ event }: { event: CalendarEvent }) {
       draggable
       onDragStart={handleDragStart}
       onClick={handleClick}
-      className="relative z-[60] w-full h-full rounded-[4px] px-[22px] py-[4px] text-[16px] leading-[20px] text-black cursor-pointer pointer-events-auto"
+      className="relative z-[10] w-full h-full rounded-[4px] px-[22px] py-[4px] text-[16px] leading-[20px] text-black cursor-pointer pointer-events-auto"
       title={event.title ?? ''}
       role="button"
     >
-      <div className="w-full h-full flex items-center justify-center text-center break-words whitespace-normal overflow-wrap-anywhere">
+      <div className="w-full h-full flex items-center justify-center text-center break-words whitespace-normal overflow-wrap-anywhere Z-[90px]">
         {event.title || '빈 일정'}
       </div>
     </div>

--- a/src/features/teamCalendar/components/CalendarEventBox.tsx
+++ b/src/features/teamCalendar/components/CalendarEventBox.tsx
@@ -34,7 +34,7 @@ export default function CalendarEventBox({ event }: { event: CalendarEvent }) {
     if (!projectId || event?.id == null) return;
     const target = isTask
       ? `/projects/${projectId}/tasks/${taskId}`
-      : `/projects/${projectId}/teamcalendar/${String(event.id)}/teamtask`;
+      : `/projects/${projectId}/teamCalendar/${String(event.id)}/teamTask`;
     console.log('이벤트 클릭: 팀태스크로 이동', {
       projectId,
       id: String(event.id),

--- a/src/hooks/mutations/usePlan.ts
+++ b/src/hooks/mutations/usePlan.ts
@@ -11,6 +11,7 @@ export const useGetPlanDetail = (planId: string) =>
     queryKey: ['planDetail', planId],
     queryFn: () => getPlanDetail(planId),
     enabled: !!planId,
+    staleTime: 60 * 1000,
   });
 
 // Mutation Hooks

--- a/src/hooks/queries/useGetTeamCalendar.ts
+++ b/src/hooks/queries/useGetTeamCalendar.ts
@@ -6,4 +6,5 @@ export const useGetCalendarPlans = (projectId: string, startDate: string, endDat
     queryKey: ['calendarPlans', projectId, startDate, endDate],
     queryFn: () => getCalendarPlans({ projectId, startDate, endDate }),
     enabled: !!projectId && !!startDate && !!endDate,
+    staleTime: 5 * 60 * 1000,
   });

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -98,7 +98,7 @@
   overflow: visible !important;
   text-overflow: unset !important;
   display: block !important;
-  word-break: keep-all !important;
+  word-break: break-all !important;
 }
 
 /* 드래그 라인 인디케이터 대비용: 캘린더 셀은 overflow visible */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -106,3 +106,17 @@
 .rbc-date-cell {
   overflow: visible !important;
 }
+
+/* 각 주(row) */
+.rbc-month-row {
+  height: auto !important; /* 일정에 따라 자동 높이 조정 */
+}
+
+/* 날짜 셀 */
+.rbc-date-cell {
+  min-width: 200px !important; /* 가로 고정 */
+}
+
+.rbc-month-view {
+  height: auto; /* 달력 전체 높이 자동 */
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -112,6 +112,12 @@
   height: auto !important; /* 일정에 따라 자동 높이 조정 */
 }
 
+/* 드래그 라인 인디케이터 대비용: 캘린더 셀은 overflow visible */
+.rbc-day-bg,
+.rbc-date-cell {
+  overflow: visible !important;
+}
+
 /* 날짜 셀 */
 .rbc-date-cell {
   min-width: 200px !important; /* 가로 고정 */


### PR DESCRIPTION
## 연관 이슈
- Closes #222

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
- [x]  구분선 길이 수정
- [x]  표시하는 카드 수 관련 : 캘린더가 세로 사이즈로 늘어나면서 일정들 다 표시
- [x]  일정 표시 관련 → 현재 해당 월의 일정/ 업무만 조회되고 있지만, 캘린더에 나타나는 모든 날짜의 일정/ 업무가 조회되어야 함.
- [x]  일자 필드 기본 크기 고정
- [x]  달력 일자 박스 크기 수정
- [ ]  드래그앤드롭 좀 더 잘 되게 수정 ( 약간 수정 완료 )
- [ ]  날짜랑 첫 event 간격 조정 하고 싶은데(?)!!!! 잘 안됐습니다.

밑에 두 개 이것저것 다 해보고 지피티도 이제 될 거라고 했는데 반영이 잘 안되네요.. 그래도  노션 칸반에 올라온 것은 다 수정했습니다!

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-
