### PR TITLE
[Fix/258] 마스터포트폴리오 메뉴 버튼에서 프로젝트홈/개인회고 로 이동하지 않는 문제

### DIFF
--- a/src/features/aimasterportfolio/components/MenuButton.tsx
+++ b/src/features/aimasterportfolio/components/MenuButton.tsx
@@ -19,13 +19,17 @@ export default function MenuButton() {
   const menuItems = [
     {
       label: '프로젝트 홈으로 이동',
-      href: '#',
+      href: `/projects/${projectId || ''}`,
       onClick: () => router.push(`/projects/${projectId}`),
     },
     {
       label: '개인 회고로 이동',
-      href: '#',
-      onClick: () => projectId && router.push(`/projects/${projectId}/retrospect/create`),
+      href: `/projects/${projectId || ''}/retrospect/create`,
+      onClick: () => {
+        if (projectId) {
+          router.push(`/projects/${projectId}/retrospect/create`);
+        }
+      },
     },
   ];
 


### PR DESCRIPTION
## 연관 이슈
- Closes #258

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
마스터포트폴리오 메뉴 버튼에서 프로젝트홈/개인회고 로 이동하지 않는 문제해결했습니다.
컴포넌트로 바꿔 쓰면서 코드가 바뀌게 되었는데 href: '#' 으로 인해 onClick이 실행되지만, Link의 기본 동작과 충돌이 나서 안 되었던 것 같습니다..!

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-
