### PR TITLE
[Fix/274] 웹소켓 강제 구독 해제 시 리다이렉트 경로 변경

### DIFF
--- a/src/app/(main)/projects/[projectId]/dashboard/page.tsx
+++ b/src/app/(main)/projects/[projectId]/dashboard/page.tsx
@@ -142,7 +142,10 @@ export default function DashboardPage() {
       // 3. unsubscribe-forced 이벤트 수신 - 강제 구독 해제
       const handleForceUnsubscribe = () => {
         console.log('강제 구독 해제');
-        window.location.href = '/home/tasks';
+        // 쿼리 무효화
+        queryClient.invalidateQueries({
+          queryKey: ['dashboard', projectIdNum],
+        });
       };
 
       // 이벤트 리스너 등록

--- a/src/app/(main)/projects/[projectId]/tasks/[taskId]/page.tsx
+++ b/src/app/(main)/projects/[projectId]/tasks/[taskId]/page.tsx
@@ -128,7 +128,7 @@ export default function TaskDetailPage() {
 
       const handleForceUnsubscribe = () => {
         console.log('강제 구독 해제');
-        router.push(`/projects/${projectId}/dashboard`);
+        router.back();
       };
 
       socket.on('publish', handlePublish);

--- a/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
+++ b/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
@@ -102,7 +102,9 @@ export default function TeamCalendar() {
       // 3) 강제 구독 해제 시 이동
       const handleForceUnsubscribe = () => {
         console.log('팀캘린더 강제 구독 해제');
-        window.location.href = '/home/tasks';
+        queryClient.invalidateQueries({
+          queryKey: ['calendarPlans', projectId, startDate, endDate],
+        });
       };
 
       socket.on('publish', handlePublish);


### PR DESCRIPTION
## 연관 이슈
- Closes #274

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
웹소켓 강제 구독 해제 시 리다이렉트 경로 변경했습니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-
