### PR TITLE
[Fix/291] 호버랑 플러스 버튼 뜨는 날짜 조정하기/프로젝트 생성일에 일정 추가 안되는 문제 

### DIFF
--- a/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
+++ b/src/app/(main)/projects/[projectId]/teamcalendar/page.tsx
@@ -145,8 +145,8 @@ export default function TeamCalendar() {
         const { data } = await axiosInstance.get(`/api/v1/projects/${projectId}`);
         const createdAt = data?.result?.project?.createdAt || data?.result?.createdAt;
         if (createdAt) {
-          // 프로젝트 생성일을 기준으로 currentDate 설정
-          const creationDate = moment(createdAt).toDate();
+          // 프로젝트 생성일을 기준으로 currentDate 설정 (UTC 시간 그대로 사용)
+          const creationDate = moment.utc(createdAt).toDate();
           setCurrentDate(creationDate);
 
           // 날짜 비교 오차 방지를 위해 'YYYY-MM-DD'로 전달 (타임존 영향 제거)

--- a/src/features/teamCalendar/CustomDateCellWrapper.tsx
+++ b/src/features/teamCalendar/CustomDateCellWrapper.tsx
@@ -38,9 +38,9 @@ export default function CustomDateCellWrapper({
   const { mutate } = usePostPlan();
   const { mutate: patchPlan } = usePatchPlan();
 
-  // 프로젝트 생성일 이전인지 확인
+  // 프로젝트 생성일 이전인지 확인 (전체 날짜 비교)
   const isBeforeProjectCreation = projectCreatedAtISO
-    ? moment(value).isBefore(moment(projectCreatedAtISO), 'day')
+    ? moment(value).isBefore(moment(projectCreatedAtISO))
     : false;
 
   // 플러스 버튼 표시 조건: 프로젝트 생성일 이후만, 그리고 프로젝트가 종료되지 않았을 때
@@ -49,22 +49,21 @@ export default function CustomDateCellWrapper({
   const handleClick = () => {
     if (!projectId || !canShowPlusButton) return;
 
-    // 선택한 날짜 + 현재 시간으로 조합
+    // 선택한 날짜의 현재 시간으로 설정
     const selectedDate = moment(value);
     const currentTime = moment();
-
     const formattedDate = selectedDate
       .hour(currentTime.hour())
       .minute(currentTime.minute())
       .second(currentTime.second())
       .millisecond(currentTime.millisecond())
-      .format('YYYY-MM-DDTHH:mm:ss.SSS[Z]');
+      .toISOString();
 
     console.log('플러스 버튼 클릭!', {
       projectId,
       formattedDate,
-      selectedDate: selectedDate.format('YYYY-MM-DD'),
-      currentTime: currentTime.format('HH:mm:ss'),
+      selectedDate: moment(value).format('YYYY-MM-DD'),
+      currentTime: moment().format('HH:mm:ss'),
     });
 
     mutate(
@@ -102,7 +101,7 @@ export default function CustomDateCellWrapper({
   const [indicatorY, setIndicatorY] = useState<number>(4);
   const indicatorVisible = isDragOver; // 호버 상태와 독립적으로 작동
 
-  // 드롭할 목표 날짜 문자열 (선택한 날짜 + 현재 시간으로 조합)
+  // 드롭할 목표 날짜 문자열 (선택한 날짜의 현재 시간)
   const dropTargetDate = useMemo(() => {
     const selectedDate = moment(value);
     const currentTime = moment();
@@ -112,7 +111,7 @@ export default function CustomDateCellWrapper({
       .minute(currentTime.minute())
       .second(currentTime.second())
       .millisecond(currentTime.millisecond())
-      .format('YYYY-MM-DDTHH:mm:ss.SSS[Z]');
+      .toISOString();
   }, [value]);
 
   return (

--- a/src/features/teamCalendar/CustomDateCellWrapper.tsx
+++ b/src/features/teamCalendar/CustomDateCellWrapper.tsx
@@ -38,16 +38,13 @@ export default function CustomDateCellWrapper({
   const { mutate } = usePostPlan();
   const { mutate: patchPlan } = usePatchPlan();
 
-  // 오늘 날짜 이후인지 확인 (오늘 포함)
-  const isTodayOrAfter = moment(value).isSameOrAfter(moment(), 'day');
-
   // 프로젝트 생성일 이전인지 확인
   const isBeforeProjectCreation = projectCreatedAtISO
     ? moment(value).isBefore(moment(projectCreatedAtISO), 'day')
     : false;
 
-  // 플러스 버튼 표시 조건: 오늘 이후이면서, 프로젝트 생성일 이후만, 그리고 프로젝트가 종료되지 않았을 때
-  const canShowPlusButton = isTodayOrAfter && !isBeforeProjectCreation && !isProjectCompleted;
+  // 플러스 버튼 표시 조건: 프로젝트 생성일 이후만, 그리고 프로젝트가 종료되지 않았을 때
+  const canShowPlusButton = !isBeforeProjectCreation && !isProjectCompleted;
 
   const handleClick = () => {
     if (!projectId || !canShowPlusButton) return;


### PR DESCRIPTION
## 연관 이슈
- Closes #291

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
1. 호버랑 플러스 버튼 프로젝트 생성일포함, 이후에만 뜨도록 수정
플러스버튼이랑 호버버튼이 오늘날짜 & 프로젝트 생성일 이전이 아닐때 & 프로젝트 종료 전이 아닐때  이렇게 조건이 걸려 있어서 오늘 날짜 이후에만 생겼는데 오늘 날짜를 제거해서 프로젝트 생성일 포함, 이후만 된다. 라는 것으로 수정했습니다.

2. 프로젝트 생성일에도 일정이 생기도록 수정
프로젝트 생성일에 일정이 안 생기는 문제를 고쳤다고 생각했는데 여태 date를 서버 시간이 아니라 플러스버튼을 눌렀을 때 선택한 날짜와 시간으로 받고 있어서 서버 시간으로 받는 것으로 수정했습니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-
