### PR TITLE
[Fix/298] 사용자 프로필 이미지 깨짐

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -9,6 +9,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { SidebarMenus } from '@/types/sidebar';
 import Dropdown from './Dropdown';
 import Image from 'next/image';
+import { getDropdownIcon, getProfileImageUrl, handleImageError } from '@/utils/imageUtils';
 
 export default function Navbar() {
   const [openMenu, setOpenMenu] = useState<string | null>(null);
@@ -204,7 +205,8 @@ export default function Navbar() {
             trigger={
               <button data-dropdown-trigger className="flex items-center">
                 <Image
-                  src={user?.imageUrl || '/icons/profile.svg'}
+                  src={getProfileImageUrl(user?.imageUrl)}
+                  onError={handleImageError}
                   alt="프로필"
                   className="cursor-pointer rounded-full object-cover w-[32px] h-[32px]"
                   width={32}
@@ -216,7 +218,7 @@ export default function Navbar() {
               {
                 label: '마이페이지',
                 href: '/myPage',
-                icon: user?.imageUrl ? user.imageUrl : '/icons/myPage-dropdown.svg',
+                icon: getDropdownIcon(user),
               },
               {
                 label: '로그아웃',

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -6,6 +6,7 @@ import { useUpdateTaskStatus } from '@/hooks/mutations/useUpdateTaskStatus';
 import Link from 'next/link';
 import AssigneeCard from './AssigneeCard';
 import { formatToKoreanDate } from '@/utils/formatDate';
+import { getProfileImageUrl } from '@/utils/imageUtils';
 
 // TaskItem 컴포넌트 Props에 onTaskComplete 콜백 추가
 interface TaskItemProps extends TaskItemComponentProps {
@@ -123,7 +124,7 @@ export default function TaskItem({
                 <AssigneeCard
                   key={index}
                   name={assignee.name}
-                  imageUrl={assignee.imageUrl}
+                  imageUrl={getProfileImageUrl(assignee.imageUrl)}
                   size="sm"
                 />
               ))}

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -1,0 +1,24 @@
+import { UserProfile } from '@/types/api/user';
+
+export const getProfileImageUrl = (imageUrl: string | null | undefined): string => {
+  if (!imageUrl) return '/icons/profile.svg';
+
+  try {
+    new URL(imageUrl);
+    return imageUrl;
+  } catch {
+    return '/icons/profile.svg';
+  }
+};
+
+// 이미지 에러 핸들러
+export const handleImageError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+  const target = e.target as HTMLImageElement;
+  target.src = '/icons/profile.svg';
+};
+
+// 드롭다운 아이콘용 (마이페이지 메뉴)
+export const getDropdownIcon = (user: UserProfile | null): string => {
+  const profileImage = getProfileImageUrl(user?.imageUrl);
+  return profileImage !== '/icons/profile.svg' ? profileImage : '/icons/myPage-dropdown.svg';
+};


### PR DESCRIPTION
## 연관 이슈
- Closes #298

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
- 기존에는 이미지가 falsy 값일 때만 기본 프로필을 렌더링하고 있었기에 onError 핸들러를 추가하였습니다.
- 이미지 값에 대한 처리를 강화했습니다. string | null | undefined 다 받아서 imageUrl이 이상하면 기본 프로필을 렌더링하게 됩니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 첨부 자료
-
