### PR TITLE
[Feat/263] 리프레시 토큰 추가

### DIFF
--- a/src/app/(main)/new/page.tsx
+++ b/src/app/(main)/new/page.tsx
@@ -5,7 +5,7 @@ import { useCreateProject } from '@/hooks/mutations/useCreateProject';
 import { formatToKoreanDate } from '@/utils/formatDate';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useThrottle } from '@/hooks/useThrottle';
+import useThrottle from '@/hooks/useThrottle';
 import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 
@@ -20,9 +20,6 @@ export default function New() {
   const [expiresAt, setExpiresAt] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const [hasAttemptedCreation, setHasAttemptedCreation] = useState(false);
-
-  // 1초 throttle 적용
-  const throttledCreateProject = useThrottle(1000);
 
   const createProjectMutation = useCreateProject(
     (response) => {
@@ -57,6 +54,12 @@ export default function New() {
     }
   );
 
+  // 스로틀링 적용 방식 변경
+  const throttledCreateProject = useThrottle(() => {
+    if (!projectName.trim()) return;
+    createProjectMutation.mutate({ name: projectName });
+  }, 1000); // 1초에 한 번만 실행
+
   // 프로젝트명 입력 제한 함수
   const handleProjectNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -85,9 +88,7 @@ export default function New() {
     setHasAttemptedCreation(true);
 
     // throttle 적용하여 중복 요청 방지
-    throttledCreateProject(() => {
-      createProjectMutation.mutate({ name: projectName });
-    });
+    throttledCreateProject();
   };
 
   const handleRedirect = () => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import localFont from 'next/font/local';
 import { AuthProvider } from '../contexts/AuthContext';
 import { usePathname, useRouter } from 'next/navigation';
@@ -8,6 +8,8 @@ import { useEffect } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import '../styles/globals.css';
 import { WebSocketProvider } from '@/contexts/WebSocketContext';
+import { queryClient } from '@/lib/queryClient';
+import { checkAuthRoute } from '@/utils/authRoute';
 
 const pretendard = localFont({
   src: './fonts/PretendardVariable.woff2',
@@ -16,10 +18,10 @@ const pretendard = localFont({
   variable: '--font-pretendard',
 });
 
-const queryClient = new QueryClient();
+// const queryClient = new QueryClient();
 
 // 인증이 필요한 페이지들
-const PROTECTED_ROUTES = ['/home', '/projects', '/myPage', '/new'];
+// const PROTECTED_ROUTES = ['/home', '/projects', '/myPage', '/new'];
 
 function AuthWrapper({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
@@ -31,7 +33,7 @@ function AuthWrapper({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    const isProtectedRoute = PROTECTED_ROUTES.some((route) => pathname.startsWith(route));
+    const { isProtectedRoute } = checkAuthRoute(pathname);
     const isLoginPage = pathname === '/login';
 
     // 현재 전체 경로(쿼리 포함)

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -12,14 +12,14 @@ import { useUser, useUserProjects } from '@/hooks/mutations/useUser';
 import { useLogout } from '@/hooks/mutations/useLogout';
 import { UserProfile } from '@/types/api/user';
 import { useQueryClient } from '@tanstack/react-query';
-import { useRouter, usePathname } from 'next/navigation';
+import { useRouter } from 'next/navigation';
+import useThrottle from '@/hooks/useThrottle';
 
 interface AuthContextType {
   isAuthenticated: boolean;
   user: UserProfile | null;
   logout: () => Promise<void>;
   isLoading: boolean;
-  // pro 업그레이드 토글 상태 추가
   isUpgraded: boolean;
   setIsUpgraded: (value: boolean) => void;
 }
@@ -35,22 +35,30 @@ export const useAuth = () => {
 };
 
 export const AuthProvider = ({ children }: PropsWithChildren) => {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
-  const [authStatusChecked, setAuthStatusChecked] = useState(false); // 1. 인증 확인 완료 상태 추가
-  // pro 업그레이드 상태 추가
   const [isUpgraded, setIsUpgraded] = useState(false);
-  const {
-    data: userData,
-    error: userError,
-    isLoading: isUserLoading, // 2. useUser의 로딩 상태는 내부적으로만 사용
-  } = useUser();
+  const { data: userData, error: userError, isLoading: isUserLoading } = useUser();
   const { data: projects = [] } = useUserProjects(!!userData);
   const logoutMutation = useLogout();
   const queryClient = useQueryClient();
   const router = useRouter();
-  const pathname = usePathname(); // 현재 경로 추적
 
-  // 사용자 정보와 프로젝트 정보를 합친 완전한 user 객체 (UI용)
+  // 브라우저 탭 포커스 시 5초 간격으로 사용자 인증 상태를 다시 확인합니다.
+  // 다른 탭에서 로그아웃했거나 토큰이 만료된 경우를 감지하기 위함입니다.
+  const throttledRefetch = useThrottle(() => {
+    console.log('Window focused, revalidating user...');
+    queryClient.invalidateQueries({ queryKey: ['user'] });
+  }, 5000);
+
+  useEffect(() => {
+    window.addEventListener('focus', throttledRefetch);
+
+    return () => {
+      window.removeEventListener('focus', throttledRefetch);
+    };
+  }, [throttledRefetch]);
+
+  const isAuthenticated = useMemo(() => !!userData && !userError, [userData, userError]);
+
   const user = useMemo(() => {
     if (userData) {
       return {
@@ -61,43 +69,15 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
     return null;
   }, [userData, projects]);
 
-  // 페이지 이동 시마다 인증 상태를 다시 확인
-  useEffect(() => {
-    setAuthStatusChecked(false); // 로딩 상태로 전환하여 UI 깜빡임 방지
-    queryClient.invalidateQueries({ queryKey: ['user'] }); // 사용자 정보 재조회 트리거
-  }, [pathname, queryClient]);
-
-  useEffect(() => {
-    // 3. API 요청 로딩이 끝나면 인증 상태를 확정하고, 그 다음에 "인증 확인 절차 끝"으로 표시
-    if (!isUserLoading) {
-      if (userData && !userError) {
-        setIsAuthenticated(true);
-      } else if (userError) {
-        setIsAuthenticated(false);
-      }
-      setAuthStatusChecked(true); // 인증 상태 세팅이 끝난 후, 확인 완료로 변경
-    }
-  }, [userData, userError, isUserLoading]);
-
   const logout = async () => {
     try {
-      // 1. 백엔드에 로그아웃 요청 보내기 (필수)
       await logoutMutation.mutateAsync();
-
-      // 2. 전역 상태(Global State) 초기화 (매우 중요)
-      setIsAuthenticated(false);
-
-      // 3. API 클라이언트 캐시 초기화
-      queryClient.clear();
-
-      // 4. 로그인 페이지로 리다이렉트
-      router.push('/login');
     } catch (error) {
       console.error('Logout request failed:', error);
-
-      // 에러가 발생해도 로컬 상태는 초기화하고 로그인 페이지로 이동
-      setIsAuthenticated(false);
+    } finally {
+      // API 요청 성공 여부와 관계없이 항상 로컬 상태를 초기화하고 리디렉션합니다.
       queryClient.clear();
+      // isAuthenticate 상태는 queryClient.clear() 후 useUser가 다시 실행되며 자동으로 false가 됩니다.
       router.push('/login');
     }
   };
@@ -107,11 +87,11 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
       isAuthenticated,
       user,
       logout,
-      isLoading: !authStatusChecked, // 4. 외부에는 "인증 확인이 끝나지 않음"을 로딩 상태로 전달
+      isLoading: isUserLoading, // useUser의 로딩 상태를 그대로 사용합니다.
       isUpgraded,
       setIsUpgraded,
     }),
-    [isAuthenticated, user, authStatusChecked, isUpgraded]
+    [isAuthenticated, user, isUserLoading, isUpgraded]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/hooks/mutations/useUser.ts
+++ b/src/hooks/mutations/useUser.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { UserProfile, UserProject } from '@/types/api/user';
 import fetchUserProfile, {
   fetchUserProjects,
@@ -5,14 +7,27 @@ import fetchUserProfile, {
   updateMainTask,
 } from '@/services/user/user';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { usePathname } from 'next/navigation';
+import { checkAuthRoute } from '@/utils/authRoute';
 
 // 기본 사용자 정보만 가져오는 훅
 export const useUser = () => {
+  const pathname = usePathname();
+  const { isPublicPath } = checkAuthRoute(pathname);
+
   return useQuery<UserProfile>({
     queryKey: ['user'],
     queryFn: fetchUserProfile,
-    staleTime: 1000 * 60 * 5,
-    retry: false,
+    staleTime: 1000 * 60 * 5, // 5분 동안 데이터를 fresh 상태로 유지합니다.
+    refetchOnWindowFocus: !isPublicPath, // 공개 경로에서는 브라우저 창이 포커스되어도 데이터를 다시 가져오지 않습니다.
+    retry: (failureCount, error: any) => {
+      // 401 에러는 인터셉터가 처리하므로 재시도하지 않습니다.
+      if (error.response?.status === 401) {
+        return false;
+      }
+      // 그 외 에러는 2번까지 재시도합니다.
+      return failureCount < 2;
+    },
   });
 };
 

--- a/src/hooks/useThrottle.ts
+++ b/src/hooks/useThrottle.ts
@@ -1,26 +1,37 @@
-import { useRef, useCallback } from 'react';
+'use client';
 
-// 1초 이내에 동일한 요청을 방지하는 훅
-export const useThrottle = (delay: number = 1000) => {
+import { useRef, useCallback, useEffect } from 'react';
+
+// useThrottle 훅은 콜백 함수의 실행 빈도를 제한합니다.
+// 지정된 delay 시간 동안 콜백 함수가 최대 한 번만 호출되도록 보장합니다.
+const useThrottle = <T extends (...args: any[]) => void>(callback: T, delay: number) => {
+  const throttleId = useRef<NodeJS.Timeout | null>(null);
   const isThrottled = useRef(false);
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const throttledFunction = useCallback(
-    (fn: () => void) => {
-      if (isThrottled.current) {
-        console.log('요청이 너무 빠릅니다. 잠시 후 다시 시도해주세요.');
-        return;
+  const throttledCallback = useCallback(
+    (...args: Parameters<T>) => {
+      if (!isThrottled.current) {
+        callback(...args);
+        isThrottled.current = true;
+        throttleId.current = setTimeout(() => {
+          isThrottled.current = false;
+          throttleId.current = null;
+        }, delay);
       }
-
-      isThrottled.current = true;
-      fn();
-
-      timeoutRef.current = setTimeout(() => {
-        isThrottled.current = false;
-      }, delay);
     },
-    [delay]
+    [callback, delay]
   );
 
-  return throttledFunction;
+  // 컴포넌트가 언마운트될 때 타이머를 정리합니다.
+  useEffect(() => {
+    return () => {
+      if (throttleId.current) {
+        clearTimeout(throttleId.current);
+      }
+    };
+  }, []);
+
+  return throttledCallback;
 };
+
+export default useThrottle;

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -1,6 +1,9 @@
 // 공용 axios 인스턴스
 
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
+import { refreshToken } from '../services/auth/refreshToken';
+import { queryClient } from './queryClient';
+import { ApiErrorResponse } from '@/types/api/error';
 
 const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
@@ -10,24 +13,90 @@ const axiosInstance = axios.create({
   },
 });
 
+// 리프레시 토큰 인터셉터 로직
+// 재발급 요청이 진행 중인지 여부를 나타내는 플래그
+let isRefreshing = false;
+// 재발급 중에 실패한 요청들을 저장하는 배열
+let failedQueue: { resolve: (value?: unknown) => void; reject: (reason?: unknown) => void }[] = [];
+
+const processQueue = (error: Error | null) => {
+  failedQueue.forEach((prom) => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve();
+    }
+  });
+  failedQueue = [];
+};
+
 axiosInstance.interceptors.response.use(
   (response) => {
     // 2xx 범위의 상태 코드는 이 함수를 트리거합니다.
     return response;
   },
-  (error) => {
-    if (error.response?.status === 401) {
-      console.error('401 Unauthorized - 인증이 필요합니다.');
-    } else if (error.response?.data?.error?.errorCode === 'PROJECT4031') {
+  async (error: AxiosError) => {
+    const originalRequest = error.config;
+
+    // 토큰 재발급 요청 자체에서 에러가 발생한 경우, 재시도 로직을 실행하지 않습니다.
+    if (originalRequest?.url === '/auth/refresh') {
+      console.error('리프레시 토큰이 만료되었거나 유효하지 않습니다. 로그아웃 처리합니다.');
+      return Promise.reject(error);
+    }
+
+    // 로그인 페이지나 콜백 페이지에서는 재발급 로직을 실행하지 않습니다.
+    if (typeof window !== 'undefined') {
+      const { pathname } = window.location;
+      if (pathname === '/login' || pathname.includes('/callback')) {
+        return Promise.reject(error);
+      }
+    }
+
+    // 401 에러가 발생했고, 재시도한 요청이 아닐 때만 로직을 실행합니다.
+    if (error.response?.status === 401 && originalRequest && !(originalRequest as any)._retry) {
+      // 이미 토큰 재발급이 진행 중이라면, 현재 요청을 큐에 추가합니다.
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then(() => axiosInstance(originalRequest))
+          .catch((err) => Promise.reject(err));
+      }
+
+      (originalRequest as any)._retry = true;
+      isRefreshing = true;
+
+      try {
+        // 토큰을 재발급합니다.
+        await refreshToken();
+        console.log('토큰 재발급 성공. 원래 요청을 재시도합니다.');
+        processQueue(null);
+        return axiosInstance(originalRequest);
+      } catch (refreshError) {
+        console.error('토큰 재발급 실패:', refreshError);
+        processQueue(refreshError as Error);
+
+        // 재발급에 실패하면 캐시를 초기화하고 로그인 페이지로 이동시킵니다.
+        queryClient.clear();
+        if (typeof window !== 'undefined') {
+          window.location.href = '/login';
+        }
+
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
+    } else if ((error.response?.data as ApiErrorResponse)?.errorCode === 'PROJECT4031') {
       console.error('PROJECT4031 - 프로젝트 접근 권한이 없습니다. 홈으로 이동합니다.');
-      // 홈으로 리다이렉트
+      // 홈으로 리다이렉트합니다.
       if (typeof window !== 'undefined') {
-        // 임시로 알림창 띄우기
+        // 임시로 알림창을 띄웁니다.
         alert('잘못된 접근입니다.');
-        // 강제로 페이지 이동
+        // 강제로 페이지를 이동시킵니다.
         window.location.replace('/home/tasks');
       }
     }
+
     return Promise.reject(error);
   }
 );

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient();

--- a/src/services/auth/refreshToken.ts
+++ b/src/services/auth/refreshToken.ts
@@ -1,0 +1,19 @@
+import axiosInstance from '@/lib/axiosInstance';
+
+// 토큰 재발급 API 응답 타입
+interface RefreshResponse {
+  isSuccess: boolean;
+  error: {
+    errorCode: string;
+    reason: string;
+    data: null;
+  } | null;
+  result: string | null;
+}
+
+// Refresh Token을 사용하여 Access Token을 재발급받는 함수입니다.
+// 재발급에 실패하면 에러를 발생시킵니다.
+export const refreshToken = async (): Promise<void> => {
+  // POST 요청 시 body는 비워둡니다.
+  await axiosInstance.post<RefreshResponse>('/auth/refresh');
+};

--- a/src/services/user/user.ts
+++ b/src/services/user/user.ts
@@ -11,11 +11,16 @@ import axiosInstance from '@/lib/axiosInstance';
 
 // 사용자 프로필 정보를 가져오는 함수
 export default async function fetchUserProfile(): Promise<UserProfile> {
-  const { data } = await axiosInstance.get<UserResponse>('/api/v1/users/me');
-  if (!data.result) {
-    throw new Error('사용자 정보를 가져올 수 없습니다.');
+  try {
+    const { data } = await axiosInstance.get<UserResponse>('/api/v1/users/me');
+    if (!data.result) {
+      throw new Error('사용자 정보를 가져올 수 없습니다.');
+    }
+    return data.result;
+  } catch (error) {
+    console.error('fetchUserProfile 에러:', error);
+    throw error; // 에러를 다시 throw하여 react-query가 인지하도록 함
   }
-  return data.result;
 }
 
 // 주요 업무를 수정하는 함수

--- a/src/utils/authRoute.ts
+++ b/src/utils/authRoute.ts
@@ -1,0 +1,20 @@
+// src/utils/authRoute.ts
+
+// 인증이 필요한 페이지 경로의 접두사입니다.
+const PROTECTED_ROUTES = ['/home', '/projects', '/myPage', '/new'];
+
+// 인증이 필요 없는 공개 페이지 경로입니다.
+const PUBLIC_PATHS = ['/login', '/callback'];
+
+interface AuthRouteStatus {
+  isProtectedRoute: boolean;
+  isPublicPath: boolean;
+}
+
+// 주어진 경로(pathname)가 보호된 경로인지, 공개 경로인지 확인하는 유틸리티 함수입니다.
+export const checkAuthRoute = (pathname: string): AuthRouteStatus => {
+  const isProtectedRoute = PROTECTED_ROUTES.some((route) => pathname.startsWith(route));
+  const isPublicPath = PUBLIC_PATHS.some((path) => pathname.startsWith(path));
+
+  return { isProtectedRoute, isPublicPath };
+};


### PR DESCRIPTION
## 연관 이슈
- Closes #263 

## 작업 종류
<!-- 작업의 종류를 선택해주세요. -->
- [ ] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## 작업 내용
<!-- 변경 사항 설명 -->
- 리프레시 토큰을 이용한 자동 로그인 연장 구현했습니다. 액세스 토큰이 만료되었을 때 refreshToken 서비스 함수가 자동으로 재발급을 요청합니다. 또한 해당 쿼리 클라이언트가 전역으로 관리되도록 공유 인스턴스로 분리했습니다.
- axios에 인터셉터를 추가하여, 액세스 토큰 만료 시 자동으로 토큰을 갱신하고 실패했던 요청을 재시도하는 로직을 구현했습니다. 만약 리프레시 토큰마저 만료되어 갱신에 실패하면, 모든 캐시를 비우고 로그인 페이지로 안전하게 이동시킵니다.
-  사용자가 다른 탭이나 프로그램을 사용하다가 다시 앱으로 돌아왔을 때 사용자의 로그인 상태를 다시 확인하는 기능을 추가했습니다(클릭 기반). 여기에 throttle 적용해서 focus 이벤트가 연달아 발생해도 실제 API 호출은 5초에 한 번만 일어나도록 해뒀습니다.
- 유지보수성을 높이기 위해 여러 파일에 흩어져 있던 인증 관련 경로(PROTECTED_ROUTES, PUBLIC_PATHS)를 src/utils/authRoute.ts 파일로 통합했습니다.

## 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
제가 구현한 로직으로 인해 본인 페이지에 영향이 가거나 머지했을 때 오류가 발생할 수 있는 곳이 있다면 알려주세요!! 인증 관련, 경로 라우팅 관련, 혹은 제가 구현한 useThrottle 훅을 가져다 쓰시던 페이지가 있거나 axios 인터셉트 관련 구현해둔 것이 있다면 다 알려주시면 됩니다.

## 첨부 자료
-
